### PR TITLE
Rolling back changes to  'i18n-util' code

### DIFF
--- a/i18n-util/src/LocaleUtil.js
+++ b/i18n-util/src/LocaleUtil.js
@@ -1,6 +1,6 @@
 const LOCALE_COOKIE_KEY = 'okta_help_user_lang';
 import { getUrlParameter } from './UrlUtil';
-
+ 
 const  getLocale = () => {
   // map to convert locales to folder names within h.o.c
   // only end-user docs have translations
@@ -36,9 +36,22 @@ const  getLocale = () => {
 
   setLocaleCookie(locale);
 
+  // only end-user docs have translations
   // TODO remove check once admin docs also have translations OKTA-356320
-  locale = supportedLocaleToFolderMap[locale];
+  const type = getUrlParameter('type');
+  if (type) {
+    // convert locale value to folder path
+    locale = supportedLocaleToFolderMap[locale];
+  } else {
+    // always return en for admin docs
+    locale = 'en';
+  }
 
+  if (!locale) {
+    // TODO add better default logic for unsupported locales OKTA-356251
+    locale = type ? 'en-us': 'en';
+  }
+  
   return locale;
 };
 
@@ -47,15 +60,13 @@ const getCookieValue = (cookieName) => {
   return b ? b.pop() : '';
 };
 
-// Removed the conditional statement > don't we always want to reset
-// the cookie when calling this function?
-// If not, then let's doc/test the scenarios
 const setLocaleCookie = (locale) => {
-  document.cookie = `${LOCALE_COOKIE_KEY}=${locale}`;
+  if (document.cookie.indexOf(LOCALE_COOKIE_KEY) === -1) {
+    document.cookie = `${LOCALE_COOKIE_KEY}=${locale}`;
+  }
 };
 
 export {
   getLocale,
-  setLocaleCookie,
-  getCookieValue
+  setLocaleCookie
 };

--- a/i18n-util/src/UrlUtil.js
+++ b/i18n-util/src/UrlUtil.js
@@ -16,15 +16,14 @@ const getRedirectUrl = () =>  {
   // Currently type is only used for end-user docs. In the future it will be used for admin docs
   const type = getUrlParameter('type');
   const id = getUrlParameter('id');
-  /**
-   * "host": `https://help.okta.com`
-   * "type": `oie` | `wf` | `asa` | `eu` | `oag`
-   *    "type" is not provided for links to "Classic" engine content
-   * "locale": `en-us` | `ja-jp`
+  /** 
+   * env is only added to support the current version of admin docs that dont have any translations
+   * and are under en/prod folder. https://github.com/okta/okta-help/tree/gh-pages/en/prod
    * **/
+  const env = 'prod';
   const redirectUrl = type ?
     `${host}/${type}/${locale}/${fileName}#cshid=${id}`:
-    `${host}/${locale}/${fileName}#cshid=${id}`;
+    `${host}/${locale}/${env}/${fileName}#cshid=${id}`;
   return redirectUrl;
 
 };
@@ -32,4 +31,4 @@ const getRedirectUrl = () =>  {
 export {
   getRedirectUrl,
   getUrlParameter
-};
+}; 

--- a/i18n-util/test/spec/LocaleUtil_spec.js
+++ b/i18n-util/test/spec/LocaleUtil_spec.js
@@ -1,4 +1,4 @@
-import { getLocale, getCookieValue, setLocaleCookie } from '../../src/LocaleUtil';
+import { getLocale, setLocaleCookie } from '../../src/LocaleUtil';
 
 const LOCALE_COOKIE_KEY = 'okta_help_user_lang';
 let languageGetter;
@@ -24,13 +24,14 @@ describe('Locale Priority', () => {
   test('cookie locale is higher than browser locale', () => {
     languageGetter.mockReturnValue('ja-JP');
     setLocaleCookie('en-US');
-    expect(getLocale()).toBe('en-us');
+    expect(getLocale()).toBe('en');
   });
   test('browser locale is picked if query and hash is not set', () => {
     languageGetter.mockReturnValue('ja-JP');
-    expect(getLocale()).toBe('ja-jp');
+    expect(getLocale()).toBe('en');
   });
 });
+
 
 describe('LocaleUtil.setLocaleCookie', () => {
   beforeEach(() => {
@@ -38,24 +39,15 @@ describe('LocaleUtil.setLocaleCookie', () => {
   });
   test('test setLocaleCookie with "en"', () => {
     setLocaleCookie('en-US');
-    expect(getLocale()).toBe('en-us');
+    expect(getLocale()).toBe('en');
   });
-
-  // What is the intention of this test?
-  test('test setLocaleCookie with "en-US" if "okta_help_user_lang" set to ja before', () => {
+  test('test setLocaleCookie with "en" if "okta_help_user_lang" set to ja before', () => {
     document.cookie = 'cookie1=test';
     document.cookie = `${LOCALE_COOKIE_KEY}=ja-JP`;
-    // Verify that the cookie value has been set to ja-JP
-    const locale = getCookieValue(LOCALE_COOKIE_KEY);
-    expect(locale).toEqual('ja-JP')
-    // Verify that the cookie entry has an index value
-    expect(document.cookie.indexOf('okta_help_user_lang=ja-JP')).toBe(0);
-    // Reset the cookie value
+
     setLocaleCookie('en-US');
-    expect(getLocale()).toBe('en-us');
-    // Previously this test checked for a -1 value
-    // but by removing the conditional statement
-    expect(document.cookie.indexOf('okta_help_user_lang=en-US')).toBe(0);
+    expect(getLocale()).toBe('en');
+    expect(document.cookie.indexOf('okta_help_user_lang=en-US')).toBe(-1);
   });
 });
 
@@ -72,12 +64,12 @@ describe('LocaleUtil.getLocale', () => {
 
   test('test getLocale from cookie', () => {
     setLocaleCookie('ja-JP');
-    expect(getLocale()).toBe('ja-jp');
+    expect(getLocale()).toBe('en');
   });
 
   test('test getLocale from browser', () => {
     languageGetter.mockReturnValue('ja-JP');
-    expect(getLocale()).toBe('ja-jp');
+    expect(getLocale()).toBe('en');
   });
 });
 
@@ -89,7 +81,7 @@ describe('LocaleUtil.getLocale with country code for admin', () => {
     // issues with mocking window.location.href, setting window.location.hash instead here.
     window.location.hash = '?id=somehas&locale=en-US';
     setLocaleCookie('ja-JP');
-    expect(getLocale()).toBe('en-us');
+    expect(getLocale()).toBe('en');
   });
 });
 

--- a/i18n-util/test/spec/UrlUtil_spec.js
+++ b/i18n-util/test/spec/UrlUtil_spec.js
@@ -1,38 +1,28 @@
 import { getRedirectUrl, getUrlParameter } from '../../src/UrlUtil';
 
-const LOCALE_COOKIE_KEY = 'okta_help_user_lang';
-let languageGetter;
-
-// Moved setup() to file level, and then added code to clear out
-// cookie and browser values before each test run
-// to avoid these leaking
-const setup = (href) => {
-  // reset values
-  jest.clearAllMocks();
-  window.location.hash = '';
-  document.cookie = `${LOCALE_COOKIE_KEY}= ; expires = Thu, 01 Jan 1970 00:00:00 GMT`;
-  languageGetter = jest.spyOn(window.navigator, 'language', 'get');
-  let windowSpy = jest.spyOn(window, 'window', 'get');
-  windowSpy.mockImplementation(() => {
-    return {
-      location: {
-        href,
-      }
-    };
-  });
-};
-
 describe('UrlUtil.getRedirectUrl', () => {
+  const setup = (href) => {
+    // reset values
+    jest.clearAllMocks();
+    let windowSpy = jest.spyOn(window, 'window', 'get');
+    windowSpy.mockImplementation(() => {
+      return {
+        location: {
+          href,
+        }
+      };
+    });
+  };
   test('generates redirect url correctly for admin docs with locale query param', () => {
     setup('help.foo.com/okta_help.htm?id=csh-user-ov-overview&locale=ja');
     const result = getRedirectUrl();
-    expect(result).toEqual('help.foo.com/ja-jp/okta_help.htm#cshid=csh-user-ov-overview');
+    expect(result).toEqual('help.foo.com/en/prod/okta_help.htm#cshid=csh-user-ov-overview');
   });
 
   test('generates redirect url correctly for admin docs without locale query param', () => {
     setup('help.foo.com/okta_help.htm?id=csh-user-ov-overview');
     const result = getRedirectUrl();
-    expect(result).toEqual('help.foo.com/en-us/okta_help.htm#cshid=csh-user-ov-overview');
+    expect(result).toEqual('help.foo.com/en/prod/okta_help.htm#cshid=csh-user-ov-overview');
   });
 
   test('generates redirect url correctly for end-user docs with locale query param', () => {
@@ -42,7 +32,7 @@ describe('UrlUtil.getRedirectUrl', () => {
   });
 
   test('generates redirect url correctly for end-user docs without locale query param', () => {
-    setup('help.foo.com/okta_help.htm?id=csh-user-ov-overview&type=end-user');
+    setup('help.foo.com/okta_help.htm?id=csh-user-ov-overview&type=end-user&locale=en');
     const result = getRedirectUrl();
     expect(result).toEqual('help.foo.com/end-user/en-us/okta_help.htm#cshid=csh-user-ov-overview');
   });
@@ -56,6 +46,18 @@ describe('UrlUtil.getRedirectUrl', () => {
 });
 
 describe('UrlUtil.getUrlParameter', () => {
+  const setup = (href) => {
+    // reset values
+    jest.clearAllMocks();
+    let windowSpy = jest.spyOn(window, 'window', 'get');
+    windowSpy.mockImplementation(() => {
+      return {
+        location: {
+          href,
+        }
+      };
+    });
+  };
   test('extracts locale query param correctly', () => {
     setup('cshid=Settings_Emails_SMS&locale=ja-JP&type=end-user');
     const result = getUrlParameter('locale');

--- a/i18n-util/yarn.lock
+++ b/i18n-util/yarn.lock
@@ -2,13 +2,6 @@
 # yarn lockfile v1
 
 
-"@ampproject/remapping@^2.1.0":
-  version "2.1.2"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@ampproject/remapping/-/remapping-2.1.2.tgz#4edca94973ded9630d20101cd8559cedb8d8bd34"
-  integrity sha1-TtypSXPe2WMNIBAc2FWc7bjYvTQ=
-  dependencies:
-    "@jridgewell/trace-mapping" "^0.3.0"
-
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.11":
   version "7.12.11"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
@@ -16,22 +9,10 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.16.7":
-  version "7.16.7"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
-  integrity sha1-REFra9diS5mPWxr11HCFbEATh4k=
-  dependencies:
-    "@babel/highlight" "^7.16.7"
-
 "@babel/compat-data@^7.12.5", "@babel/compat-data@^7.12.7":
   version "7.12.7"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/compat-data/-/compat-data-7.12.7.tgz#9329b4782a7d6bbd7eef57e11addf91ee3ef1e41"
   integrity sha1-kym0eCp9a71+71fhGt35HuPvHkE=
-
-"@babel/compat-data@^7.16.4":
-  version "7.17.0"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/compat-data/-/compat-data-7.17.0.tgz#86850b8597ea6962089770952075dcaabb8dba34"
-  integrity sha1-hoULhZfqaWIIl3CVIHXcqruNujQ=
 
 "@babel/core@^7.1.0", "@babel/core@^7.7.5":
   version "7.12.10"
@@ -54,42 +35,12 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.14.3":
-  version "7.17.5"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/core/-/core-7.17.5.tgz#6cd2e836058c28f06a4ca8ee7ed955bbf37c8225"
-  integrity sha1-bNLoNgWMKPBqTKjuftlVu/N8giU=
-  dependencies:
-    "@ampproject/remapping" "^2.1.0"
-    "@babel/code-frame" "^7.16.7"
-    "@babel/generator" "^7.17.3"
-    "@babel/helper-compilation-targets" "^7.16.7"
-    "@babel/helper-module-transforms" "^7.16.7"
-    "@babel/helpers" "^7.17.2"
-    "@babel/parser" "^7.17.3"
-    "@babel/template" "^7.16.7"
-    "@babel/traverse" "^7.17.3"
-    "@babel/types" "^7.17.0"
-    convert-source-map "^1.7.0"
-    debug "^4.1.0"
-    gensync "^1.0.0-beta.2"
-    json5 "^2.1.2"
-    semver "^6.3.0"
-
 "@babel/generator@^7.12.10", "@babel/generator@^7.12.11":
   version "7.12.11"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/generator/-/generator-7.12.11.tgz#98a7df7b8c358c9a37ab07a24056853016aba3af"
   integrity sha1-mKffe4w1jJo3qweiQFaFMBaro68=
   dependencies:
     "@babel/types" "^7.12.11"
-    jsesc "^2.5.1"
-    source-map "^0.5.0"
-
-"@babel/generator@^7.17.3":
-  version "7.17.3"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/generator/-/generator-7.17.3.tgz#a2c30b0c4f89858cb87050c3ffdfd36bdf443200"
-  integrity sha1-osMLDE+JhYy4cFDD/9/Ta99EMgA=
-  dependencies:
-    "@babel/types" "^7.17.0"
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
@@ -117,16 +68,6 @@
     "@babel/helper-validator-option" "^7.12.1"
     browserslist "^4.14.5"
     semver "^5.5.0"
-
-"@babel/helper-compilation-targets@^7.16.7":
-  version "7.16.7"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz#06e66c5f299601e6c7da350049315e83209d551b"
-  integrity sha1-BuZsXymWAebH2jUASTFegyCdVRs=
-  dependencies:
-    "@babel/compat-data" "^7.16.4"
-    "@babel/helper-validator-option" "^7.16.7"
-    browserslist "^4.17.5"
-    semver "^6.3.0"
 
 "@babel/helper-create-class-features-plugin@^7.12.1":
   version "7.12.1"
@@ -156,13 +97,6 @@
     "@babel/types" "^7.10.5"
     lodash "^4.17.19"
 
-"@babel/helper-environment-visitor@^7.16.7":
-  version "7.16.7"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz#ff484094a839bde9d89cd63cba017d7aae80ecd7"
-  integrity sha1-/0hAlKg5venYnNY8ugF9eq6A7Nc=
-  dependencies:
-    "@babel/types" "^7.16.7"
-
 "@babel/helper-explode-assignable-expression@^7.10.4":
   version "7.12.1"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.12.1.tgz#8006a466695c4ad86a2a5f2fb15b5f2c31ad5633"
@@ -179,15 +113,6 @@
     "@babel/template" "^7.12.7"
     "@babel/types" "^7.12.11"
 
-"@babel/helper-function-name@^7.16.7":
-  version "7.16.7"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz#f1ec51551fb1c8956bc8dd95f38523b6cf375f8f"
-  integrity sha1-8exRVR+xyJVryN2V84Ujts83X48=
-  dependencies:
-    "@babel/helper-get-function-arity" "^7.16.7"
-    "@babel/template" "^7.16.7"
-    "@babel/types" "^7.16.7"
-
 "@babel/helper-get-function-arity@^7.12.10":
   version "7.12.10"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz#b158817a3165b5faa2047825dfa61970ddcc16cf"
@@ -195,26 +120,12 @@
   dependencies:
     "@babel/types" "^7.12.10"
 
-"@babel/helper-get-function-arity@^7.16.7":
-  version "7.16.7"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz#ea08ac753117a669f1508ba06ebcc49156387419"
-  integrity sha1-6gisdTEXpmnxUIugbrzEkVY4dBk=
-  dependencies:
-    "@babel/types" "^7.16.7"
-
 "@babel/helper-hoist-variables@^7.10.4":
   version "7.10.4"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz#d49b001d1d5a68ca5e6604dda01a6297f7c9381e"
   integrity sha1-1JsAHR1aaMpeZgTdoBpil/fJOB4=
   dependencies:
     "@babel/types" "^7.10.4"
-
-"@babel/helper-hoist-variables@^7.16.7":
-  version "7.16.7"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz#86bcb19a77a509c7b77d0e22323ef588fa58c246"
-  integrity sha1-hryxmnelCce3fQ4iMj71iPpYwkY=
-  dependencies:
-    "@babel/types" "^7.16.7"
 
 "@babel/helper-member-expression-to-functions@^7.12.1", "@babel/helper-member-expression-to-functions@^7.12.7":
   version "7.12.7"
@@ -230,13 +141,6 @@
   dependencies:
     "@babel/types" "^7.12.5"
 
-"@babel/helper-module-imports@^7.16.7":
-  version "7.16.7"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz#25612a8091a999704461c8a222d0efec5d091437"
-  integrity sha1-JWEqgJGpmXBEYciiItDv7F0JFDc=
-  dependencies:
-    "@babel/types" "^7.16.7"
-
 "@babel/helper-module-transforms@^7.12.1":
   version "7.12.1"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz#7954fec71f5b32c48e4b303b437c34453fd7247c"
@@ -251,20 +155,6 @@
     "@babel/traverse" "^7.12.1"
     "@babel/types" "^7.12.1"
     lodash "^4.17.19"
-
-"@babel/helper-module-transforms@^7.16.7":
-  version "7.17.6"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/helper-module-transforms/-/helper-module-transforms-7.17.6.tgz#3c3b03cc6617e33d68ef5a27a67419ac5199ccd0"
-  integrity sha1-PDsDzGYX4z1o71onpnQZrFGZzNA=
-  dependencies:
-    "@babel/helper-environment-visitor" "^7.16.7"
-    "@babel/helper-module-imports" "^7.16.7"
-    "@babel/helper-simple-access" "^7.16.7"
-    "@babel/helper-split-export-declaration" "^7.16.7"
-    "@babel/helper-validator-identifier" "^7.16.7"
-    "@babel/template" "^7.16.7"
-    "@babel/traverse" "^7.17.3"
-    "@babel/types" "^7.17.0"
 
 "@babel/helper-optimise-call-expression@^7.10.4", "@babel/helper-optimise-call-expression@^7.12.10":
   version "7.12.10"
@@ -304,13 +194,6 @@
   dependencies:
     "@babel/types" "^7.12.1"
 
-"@babel/helper-simple-access@^7.16.7":
-  version "7.16.7"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz#d656654b9ea08dbb9659b69d61063ccd343ff0f7"
-  integrity sha1-1lZlS56gjbuWWbadYQY8zTQ/8Pc=
-  dependencies:
-    "@babel/types" "^7.16.7"
-
 "@babel/helper-skip-transparent-expression-wrappers@^7.12.1":
   version "7.12.1"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz#462dc63a7e435ade8468385c63d2b84cce4b3cbf"
@@ -325,32 +208,15 @@
   dependencies:
     "@babel/types" "^7.12.11"
 
-"@babel/helper-split-export-declaration@^7.16.7":
-  version "7.16.7"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz#0b648c0c42da9d3920d85ad585f2778620b8726b"
-  integrity sha1-C2SMDELanTkg2FrVhfJ3hiC4cms=
-  dependencies:
-    "@babel/types" "^7.16.7"
-
 "@babel/helper-validator-identifier@^7.10.4", "@babel/helper-validator-identifier@^7.12.11":
   version "7.12.11"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
   integrity sha1-yaHwIZF9y1zPDU5FPjmQIpgfye0=
 
-"@babel/helper-validator-identifier@^7.16.7":
-  version "7.16.7"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
-  integrity sha1-6MYCQ4xKgZV1EkPakDHRYH0kfK0=
-
 "@babel/helper-validator-option@^7.12.1", "@babel/helper-validator-option@^7.12.11":
   version "7.12.11"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/helper-validator-option/-/helper-validator-option-7.12.11.tgz#d66cb8b7a3e7fe4c6962b32020a131ecf0847f4f"
   integrity sha1-1my4t6Pn/kxpYrMgIKEx7PCEf08=
-
-"@babel/helper-validator-option@^7.16.7":
-  version "7.16.7"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz#b203ce62ce5fe153899b617c08957de860de4d23"
-  integrity sha1-sgPOYs5f4VOJm2F8CJV96GDeTSM=
 
 "@babel/helper-wrap-function@^7.10.4":
   version "7.12.3"
@@ -371,15 +237,6 @@
     "@babel/traverse" "^7.12.5"
     "@babel/types" "^7.12.5"
 
-"@babel/helpers@^7.17.2":
-  version "7.17.2"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/helpers/-/helpers-7.17.2.tgz#23f0a0746c8e287773ccd27c14be428891f63417"
-  integrity sha1-I/CgdGyOKHdzzNJ8FL5CiJH2NBc=
-  dependencies:
-    "@babel/template" "^7.16.7"
-    "@babel/traverse" "^7.17.0"
-    "@babel/types" "^7.17.0"
-
 "@babel/highlight@^7.10.4":
   version "7.10.4"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/highlight/-/highlight-7.10.4.tgz#7d1bdfd65753538fabe6c38596cdb76d9ac60143"
@@ -389,24 +246,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/highlight@^7.16.7":
-  version "7.16.10"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/highlight/-/highlight-7.16.10.tgz#744f2eb81579d6eea753c227b0f570ad785aba88"
-  integrity sha1-dE8uuBV51u6nU8InsPVwrXhauog=
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.16.7"
-    chalk "^2.0.0"
-    js-tokens "^4.0.0"
-
 "@babel/parser@^7.1.0", "@babel/parser@^7.12.10", "@babel/parser@^7.12.11", "@babel/parser@^7.12.7", "@babel/parser@^7.7.0":
   version "7.12.11"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/parser/-/parser-7.12.11.tgz#9ce3595bcd74bc5c466905e86c535b8b25011e79"
   integrity sha1-nONZW810vFxGaQXobFNbiyUBHnk=
-
-"@babel/parser@^7.16.7", "@babel/parser@^7.17.3":
-  version "7.17.3"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/parser/-/parser-7.17.3.tgz#b07702b982990bf6fdc1da5049a23fece4c5c3d0"
-  integrity sha1-sHcCuYKZC/b9wdpQSaI/7OTFw9A=
 
 "@babel/plugin-proposal-async-generator-functions@^7.12.1":
   version "7.12.12"
@@ -961,15 +804,6 @@
     "@babel/parser" "^7.12.7"
     "@babel/types" "^7.12.7"
 
-"@babel/template@^7.16.7":
-  version "7.16.7"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
-  integrity sha1-jRJshwH95NZrJks+uj2W8HZm0VU=
-  dependencies:
-    "@babel/code-frame" "^7.16.7"
-    "@babel/parser" "^7.16.7"
-    "@babel/types" "^7.16.7"
-
 "@babel/traverse@^7.1.0", "@babel/traverse@^7.10.4", "@babel/traverse@^7.12.1", "@babel/traverse@^7.12.10", "@babel/traverse@^7.12.5", "@babel/traverse@^7.7.0":
   version "7.12.12"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/traverse/-/traverse-7.12.12.tgz#d0cd87892704edd8da002d674bc811ce64743376"
@@ -985,22 +819,6 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
-"@babel/traverse@^7.17.0", "@babel/traverse@^7.17.3":
-  version "7.17.3"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/traverse/-/traverse-7.17.3.tgz#0ae0f15b27d9a92ba1f2263358ea7c4e7db47b57"
-  integrity sha1-CuDxWyfZqSuh8iYzWOp8Tn20e1c=
-  dependencies:
-    "@babel/code-frame" "^7.16.7"
-    "@babel/generator" "^7.17.3"
-    "@babel/helper-environment-visitor" "^7.16.7"
-    "@babel/helper-function-name" "^7.16.7"
-    "@babel/helper-hoist-variables" "^7.16.7"
-    "@babel/helper-split-export-declaration" "^7.16.7"
-    "@babel/parser" "^7.17.3"
-    "@babel/types" "^7.17.0"
-    debug "^4.1.0"
-    globals "^11.1.0"
-
 "@babel/types@^7.0.0", "@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.12.1", "@babel/types@^7.12.10", "@babel/types@^7.12.11", "@babel/types@^7.12.12", "@babel/types@^7.12.5", "@babel/types@^7.12.7", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
   version "7.12.12"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/types/-/types-7.12.12.tgz#4608a6ec313abbd87afa55004d373ad04a96c299"
@@ -1008,14 +826,6 @@
   dependencies:
     "@babel/helper-validator-identifier" "^7.12.11"
     lodash "^4.17.19"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.16.7", "@babel/types@^7.17.0":
-  version "7.17.0"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@babel/types/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b"
-  integrity sha1-qCbjaLzLaz2ErNdqytXA2HNCOQs=
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -1239,24 +1049,6 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@jridgewell/resolve-uri@^3.0.3":
-  version "3.0.5"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz#68eb521368db76d040a6315cdb24bf2483037b9c"
-  integrity sha1-aOtSE2jbdtBApjFc2yS/JIMDe5w=
-
-"@jridgewell/sourcemap-codec@^1.4.10":
-  version "1.4.11"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz#771a1d8d744eeb71b6adb35808e1a6c7b9b8c8ec"
-  integrity sha1-dxodjXRO63G2rbNYCOGmx7m4yOw=
-
-"@jridgewell/trace-mapping@^0.3.0":
-  version "0.3.4"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz#f6a0832dffd5b8a6aaa633b7d9f8e8e94c83a0c3"
-  integrity sha1-9qCDLf/VuKaqpjO32fjo6UyDoMM=
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.0.3"
-    "@jridgewell/sourcemap-codec" "^1.4.10"
-
 "@sinonjs/commons@^1.7.0":
   version "1.8.2"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@sinonjs/commons/-/commons-1.8.2.tgz#858f5c4b48d80778fde4b9d541f27edc0d56488b"
@@ -1365,11 +1157,6 @@
   version "7.0.6"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha1-9MfsQ+gbMZqYFRFQMXCfJph4kfA=
-
-"@types/json-schema@^7.0.5":
-  version "7.0.9"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
-  integrity sha1-l+3JA36gw4WFMgsolk3eOznkZg0=
 
 "@types/node@*":
   version "14.14.20"
@@ -1756,16 +1543,6 @@ babel-jest@^26.6.3:
     graceful-fs "^4.2.4"
     slash "^3.0.0"
 
-babel-loader@^8.2.2:
-  version "8.2.3"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-loader/-/babel-loader-8.2.3.tgz#8986b40f1a64cacfcb4b8429320085ef68b1342d"
-  integrity sha1-iYa0Dxpkys/LS4QpMgCF72ixNC0=
-  dependencies:
-    find-cache-dir "^3.3.1"
-    loader-utils "^1.4.0"
-    make-dir "^3.1.0"
-    schema-utils "^2.6.5"
-
 babel-plugin-dynamic-import-node@^2.3.3:
   version "2.3.3"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz#84fda19c976ec5c6defef57f9427b3def66e17a3"
@@ -1902,17 +1679,6 @@ browserslist@^4.14.5, browserslist@^4.16.0:
     escalade "^3.1.1"
     node-releases "^1.1.69"
 
-browserslist@^4.17.5:
-  version "4.19.3"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/browserslist/-/browserslist-4.19.3.tgz#29b7caad327ecf2859485f696f9604214bedd383"
-  integrity sha1-KbfKrTJ+zyhZSF9pb5YEIUvt04M=
-  dependencies:
-    caniuse-lite "^1.0.30001312"
-    electron-to-chromium "^1.4.71"
-    escalade "^3.1.1"
-    node-releases "^2.0.2"
-    picocolors "^1.0.0"
-
 bser@2.1.1:
   version "2.1.1"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
@@ -1975,11 +1741,6 @@ caniuse-lite@^1.0.30001173:
   version "1.0.30001176"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/caniuse-lite/-/caniuse-lite-1.0.30001176.tgz#e44bac506d4656bae4944a1417f41597bd307335"
   integrity sha1-5EusUG1GVrrklEoUF/QVl70wczU=
-
-caniuse-lite@^1.0.30001312:
-  version "1.0.30001312"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz#e11eba4b87e24d22697dae05455d5aea28550d5f"
-  integrity sha1-4R66S4fiTSJpfa4FRV1a6ihVDV8=
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -2126,11 +1887,6 @@ commander@^6.2.0:
   version "6.2.1"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha1-B5LraC37wyWZm7K4T93duhEKxzw=
-
-commondir@^1.0.1:
-  version "1.0.1"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
-  integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
 component-emitter@^1.2.1:
   version "1.3.0"
@@ -2392,11 +2148,6 @@ electron-to-chromium@^1.3.634:
   version "1.3.637"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/electron-to-chromium/-/electron-to-chromium-1.3.637.tgz#be46f77acc217cdecf633bbd25292f6a36cc689b"
   integrity sha1-vkb3eswhfN7PYzu9JSkvajbMaJs=
-
-electron-to-chromium@^1.4.71:
-  version "1.4.73"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/electron-to-chromium/-/electron-to-chromium-1.4.73.tgz#422f6f514315bcace9615903e4a9b6b9fa283137"
-  integrity sha1-Qi9vUUMVvKzpYVkD5Km2ufooMTc=
 
 emittery@^0.7.1:
   version "0.7.2"
@@ -2773,15 +2524,6 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-find-cache-dir@^3.3.1:
-  version "3.3.2"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/find-cache-dir/-/find-cache-dir-3.3.2.tgz#b30c5b6eff0730731aea9bbd9dbecbd80256d64b"
-  integrity sha1-swxbbv8HMHMa6pu9nb7L2AJW1ks=
-  dependencies:
-    commondir "^1.0.1"
-    make-dir "^3.0.2"
-    pkg-dir "^4.1.0"
-
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
@@ -2857,7 +2599,7 @@ functional-red-black-tree@^1.0.1:
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-gensync@^1.0.0-beta.1, gensync@^1.0.0-beta.2:
+gensync@^1.0.0-beta.1:
   version "1.0.0-beta.2"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA=
@@ -3864,13 +3606,6 @@ json-stringify-safe@~5.0.1:
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@^1.0.1:
-  version "1.0.1"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
-  integrity sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=
-  dependencies:
-    minimist "^1.2.0"
-
 json5@^2.1.2:
   version "2.1.3"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
@@ -3948,15 +3683,6 @@ loader-runner@^4.2.0:
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/loader-runner/-/loader-runner-4.2.0.tgz#d7022380d66d14c5fb1d496b89864ebcfd478384"
   integrity sha1-1wIjgNZtFMX7HUlriYZOvP1Hg4Q=
 
-loader-utils@^1.4.0:
-  version "1.4.0"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
-  integrity sha1-xXm140yzSxp07cbB+za/o3HVphM=
-  dependencies:
-    big.js "^5.2.2"
-    emojis-list "^3.0.0"
-    json5 "^1.0.1"
-
 loader-utils@^2.0.0:
   version "2.0.0"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/loader-utils/-/loader-utils-2.0.0.tgz#e4cace5b816d425a166b5f097e10cd12b36064b0"
@@ -4004,7 +3730,7 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
+make-dir@^3.0.0:
   version "3.1.0"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
   integrity sha1-QV6WcEazp/HRhSd9hKpYIDcmoT8=
@@ -4180,11 +3906,6 @@ node-releases@^1.1.69:
   version "1.1.69"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/node-releases/-/node-releases-1.1.69.tgz#3149dbde53b781610cd8b486d62d86e26c3725f6"
   integrity sha1-MUnb3lO3gWEM2LSG1i2G4mw3JfY=
-
-node-releases@^2.0.2:
-  version "2.0.2"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/node-releases/-/node-releases-2.0.2.tgz#7139fe71e2f4f11b47d4d2986aaf8c48699e0c01"
-  integrity sha1-cTn+ceL08RtH1NKYaq+MSGmeDAE=
 
 normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -4431,11 +4152,6 @@ performance-now@^2.1.0:
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picocolors@^1.0.0:
-  version "1.0.0"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
-  integrity sha1-y1vcdP8/UYkiNur3nWi8RFZKuBw=
-
 picomatch@^2.0.4, picomatch@^2.0.5:
   version "2.2.2"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
@@ -4448,7 +4164,7 @@ pirates@^4.0.1:
   dependencies:
     node-modules-regexp "^1.0.0"
 
-pkg-dir@^4.1.0, pkg-dir@^4.2.0:
+pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
   integrity sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=
@@ -4824,15 +4540,6 @@ saxes@^5.0.0:
   integrity sha1-7rq5U/o7dgjb6U5drbFciI+maW0=
   dependencies:
     xmlchars "^2.2.0"
-
-schema-utils@^2.6.5:
-  version "2.7.1"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/schema-utils/-/schema-utils-2.7.1.tgz#1ca4f32d1b24c590c203b8e7a50bf0ea4cd394d7"
-  integrity sha1-HKTzLRskxZDCA7jnpQvw6kzTlNc=
-  dependencies:
-    "@types/json-schema" "^7.0.5"
-    ajv "^6.12.4"
-    ajv-keywords "^3.5.2"
 
 schema-utils@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Previous changes to 'i18n-util' code were made to enable a `lang-locale` identifier in URLs originating from Okta Admin portal for Classic/V1 pages (e.g., `https://help.okta.com/en-us/Content/index-admin.htm`).
However, after making this change, many QA tests started failing, with flaky results.
Reverting those changes for now, until we find the reason for the failures and can then apply a comprehensive fix.