### PR TITLE
Editing robots.txt file

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,9 +1,7 @@
 User-agent: *
-Disallow: /en/
-Disallow: /end-user/
 Disallow: /i18n-util/
-Disallow: /preview/
 Disallow: /Resources/
+Disallow: /tests/
 
 Sitemap: https://help.okta.com/en-us/Sitemap.xml
 Sitemap: https://help.okta.com/oie/en-us/Sitemap.xml


### PR DESCRIPTION
Removing the entries for disallowing '/en/' and '/end-user/'.
These directories contain HTML files that have noindex-nofollow metadata
set in the headers, we want that data exposed to crawlers.
Likewise, removing the disallow entry for '/preview/', that directory no longer exists.

Also, adding a disallow entry for the '/tests/' dir, crawlers don't
need to review our Cypress tests.