### PR TITLE
Adding Cypress tests to ensure tab functionality works

### DIFF
--- a/tests/cypress/integration/pdv_hoc_site_spec.js
+++ b/tests/cypress/integration/pdv_hoc_site_spec.js
@@ -15,7 +15,7 @@ describe('Test H.O.C.', () => {
     // not testable in local environments
   })
 
-  it('Classic/V1 release notes (en-US) landing page has nine tiles', () => {
+  it('Classic/V1 release notes (en-US) landing page has correct number of tiles', () => {
     cy.visit('en-us/Content/Topics/ReleaseNotes/okta-relnotes.htm')
     // The relnotes page has nine tiles, each with a link
     cy.get('p[class="tile-title"]')
@@ -53,7 +53,7 @@ describe('Test H.O.C.', () => {
         .should('not.have.attr', 'defer')
     })
 
-  it('OIE release notes (en-US) landing page has three tiles', () => {
+  it('OIE release notes (en-US) landing page has correct number of tiles', () => {
     cy.visit('oie/en-us/Content/Topics/ReleaseNotes/oie-relnotes.htm')
     // The relnotes page has three tiles, each with a link
     cy.get('p[class="tile-title"]')

--- a/tests/cypress/integration/pdv_hoc_site_spec.js
+++ b/tests/cypress/integration/pdv_hoc_site_spec.js
@@ -15,7 +15,7 @@ describe('Test H.O.C.', () => {
     // not testable in local environments
   })
 
-  it('Classic/V1 release notes (en-US)', () => {
+  it('Classic/V1 release notes (en-US) landing page has nine tiles', () => {
     cy.visit('en-us/Content/Topics/ReleaseNotes/okta-relnotes.htm')
     // The relnotes page has nine tiles, each with a link
     cy.get('p[class="tile-title"]')
@@ -29,7 +29,19 @@ describe('Test H.O.C.', () => {
       })
   })
 
-  it('OIE release notes (en-US)', () => {
+  it('Classic/V1 release notes production page tabs', () => {
+    cy.visit('en-us/Content/Topics/ReleaseNotes/production.htm')
+    // The relnotes production page has four tabs
+    cy.get('ul[id="production-tabs"] > li')
+      .should('have.length', 4)
+      // Each tab can be activated
+      .each(($li) => {
+        cy.wrap($li).click()
+          .should('have.class', 'is-active')
+      })
+    })
+
+  it('OIE release notes (en-US) landing page has three tiles', () => {
     cy.visit('oie/en-us/Content/Topics/ReleaseNotes/oie-relnotes.htm')
     // The relnotes page has three tiles, each with a link
     cy.get('p[class="tile-title"]')
@@ -42,6 +54,18 @@ describe('Test H.O.C.', () => {
           .should('have.attr', 'href')
       })
   })
+
+  it('OIE release notes production page tabs', () => {
+    cy.visit('oie/en-us/Content/Topics/ReleaseNotes/production-oie.htm')
+    // The relnotes production page has four tabs
+    cy.get('ul[id="production-tabs"] > li')
+      .should('have.length', 4)
+      // Each tab can be activated
+      .each(($li) => {
+        cy.wrap($li).click()
+          .should('have.class', 'is-active')
+      })
+    })
 
   it('Product documentation landing page (en-US)', () => {
     cy.visit('en-us/Content/index.htm')

--- a/tests/cypress/integration/pdv_hoc_site_spec.js
+++ b/tests/cypress/integration/pdv_hoc_site_spec.js
@@ -29,7 +29,7 @@ describe('Test H.O.C.', () => {
       })
   })
 
-  it('Classic/V1 release notes production page tabs', () => {
+  it('Classic/V1 release notes production page tabs work as expected', () => {
     cy.visit('en-us/Content/Topics/ReleaseNotes/production.htm')
     // The relnotes production page has four tabs
     cy.get('ul[id="production-tabs"] > li')
@@ -39,6 +39,18 @@ describe('Test H.O.C.', () => {
         cy.wrap($li).click()
           .should('have.class', 'is-active')
       })
+    })
+
+    it('Classic/V1 topics have correct script formatting', () => {
+      cy.visit('en-us/Content/Topics/ReleaseNotes/production.htm')
+      // Most scripts take the 'defer' attr
+      cy.get('head script[src*="MadCapAll.js"')
+        .should('have.attr', 'defer')
+      // The following scripts must have 'defer' attrs removed
+      cy.get('head script[src*="require.min.js"]')
+        .should('not.have.attr', 'defer')
+      cy.get('head script[src*="foundation.6.2.3_custom.js"]')
+        .should('not.have.attr', 'defer')
     })
 
   it('OIE release notes (en-US) landing page has three tiles', () => {
@@ -55,7 +67,7 @@ describe('Test H.O.C.', () => {
       })
   })
 
-  it('OIE release notes production page tabs', () => {
+  it('OIE release notes production page tabs work as expected', () => {
     cy.visit('oie/en-us/Content/Topics/ReleaseNotes/production-oie.htm')
     // The relnotes production page has four tabs
     cy.get('ul[id="production-tabs"] > li')
@@ -65,6 +77,18 @@ describe('Test H.O.C.', () => {
         cy.wrap($li).click()
           .should('have.class', 'is-active')
       })
+    })
+
+    it('OIE topics have correct script formatting', () => {
+      cy.visit('oie/en-us/Content/Topics/ReleaseNotes/production-oie.htm')
+      // Most scripts take the 'defer' attr
+      cy.get('head script[src*="MadCapAll.js"')
+        .should('have.attr', 'defer')
+      // The following scripts must have 'defer' attrs removed
+      cy.get('head script[src*="require.min.js"]')
+        .should('not.have.attr', 'defer')
+      cy.get('head script[src*="foundation.6.2.3_custom.js"]')
+        .should('not.have.attr', 'defer')
     })
 
   it('Product documentation landing page (en-US)', () => {


### PR DESCRIPTION
We had a failure in our post-deploy testing that wasn't caught by pre-deploy testing. Closing that gap. 
Adding tests for checking tab functionality on release notes pages in OIE and Classic:

- Ensure that the `defer` attributes have been removed where necessary
- Check number of tabs is as expected
- Check that each tab becomes active on click