### PR TITLE
Commits built artifact to okta-help

### DIFF
--- a/ci-scripts/commit-artifact.sh
+++ b/ci-scripts/commit-artifact.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+export ARCHIVE_PATH="target.zip"
+export OUTPUT_FOLDER="../${PUBLISH_DESTINATION}"
+export PRODUCT_NAME="${PUBLISH_DESTINATION:=oce}"
+export TOPIC_BRANCH="build-${PRODUCT_NAME}-$(date +"%Y-%m-%d_%H-%M-%S_%s")"
+
+wget -O ${ARCHIVE_PATH} ${BUILT_ARTIFACT}
+
+tar -xf ${ARCHIVE_PATH} -C ${OUTPUT_FOLDER} --strip-components=1 --overwrite
+
+rm ${ARCHIVE_PATH}
+cd ..
+
+git checkout -b ${TOPIC_BRANCH}
+
+git add --all
+git -c user.name='CI Automation' -c user.email=${userEmail} commit -m "Updates ${PRODUCT_NAME}"
+git push origin ${TOPIC_BRANCH}


### PR DESCRIPTION
Changes:
`PUBLISH_DESTINATION` and `BUILT_ARTIFACT` are passed in by `info-dev` bacon task. `BUILT_ARTIFACT` - url to the built artifact, that we want to publish. `PUBLISH_DESTINATION` - destination folder (asa, oie, e.t.c.).
For the branch name we use destination folder, which is a product name, and current timestamp to not accidentally push changes into existing branch.

Script performs next actions:
- `wget` - downloads zip from server
- `tar -xf` - extracts zip to the specified location
- `git commands` - stages changes and pushes them to the github

for the first iteration user will have to find branch on github.com/okta-help and create PR manually
<img width="1331" alt="image" src="https://user-images.githubusercontent.com/4158731/197605467-47b88715-ee9d-424e-a062-9fc98dc1084d.png">

Jira:
[OKTA-542673](https://oktainc.atlassian.net/browse/OKTA-542673)

Reviewer:
@paulwallace-okta 