### PR TITLE
Temporary adds build script to the master branch

### DIFF
--- a/ci-scripts/commit-artifact.sh
+++ b/ci-scripts/commit-artifact.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+export ARCHIVE_PATH="target.zip"
+export OUTPUT_FOLDER="../${PUBLISH_DESTINATION}"
+export PRODUCT_NAME="${PUBLISH_DESTINATION:=oce}"
+export TOPIC_BRANCH="build-${PRODUCT_NAME}-$(date +"%Y-%m-%d_%H-%M-%S_%s")"
+
+wget -O ${ARCHIVE_PATH} ${BUILT_ARTIFACT}
+
+tar -xf ${ARCHIVE_PATH} -C ${OUTPUT_FOLDER} --strip-components=1 --overwrite
+
+rm ${ARCHIVE_PATH}
+cd ..
+
+git checkout gh-pages
+git checkout -b ${TOPIC_BRANCH}
+
+git add --all
+git -c user.name='CI Automation' -c user.email=${userEmail} commit -m "Updates ${PRODUCT_NAME}"
+git push origin ${TOPIC_BRANCH}


### PR DESCRIPTION
Because of some issue on bacon side, I can't point build task to `gh-pages` branch. Instead it checks out `master` branch and fails to execute from there.
As a workaround we can merge build script to the master branch, while `eng-productivity` investigates the issue

Reviewer:
@paulwallace-okta 