### PR TITLE
Changing absolute paths to relative

### DIFF
--- a/ja-jp/Content/Topics/ReleaseNotes/early-access.htm
+++ b/ja-jp/Content/Topics/ReleaseNotes/early-access.htm
@@ -305,7 +305,7 @@
                                                 <div role="main" id="mc-main-content">
                                                     <h1 class="relnotes">未翻訳のドキュメント</h1>
                                                     <p>このページは、現在まだ翻訳されていません。最新のリリース・ノートについては、
-			<a href="https://help.okta.com/en-us/Content/Topics/ReleaseNotes/early-access.htm">リリース・ノート（英語版）</a>
+			<a href="../../../../../en-us/Content/Topics/ReleaseNotes/early-access.htm">リリース・ノート（英語版）</a>
 		をご参照ください。</p>
                                                 </div>
                                                 <!-- Back to Top button --><a href="#" class="sf-back-to-top"><span class="arrow"></span>Top</a>

--- a/ja-jp/Content/Topics/ReleaseNotes/mobile-release-status.htm
+++ b/ja-jp/Content/Topics/ReleaseNotes/mobile-release-status.htm
@@ -305,7 +305,7 @@
                                                 <div role="main" id="mc-main-content">
                                                     <h1 class="relnotes">未翻訳のドキュメント</h1>
                                                     <p>このページは、現在まだ翻訳されていません。最新のリリース・ノートについては、
-			<a href="https://help.okta.com/en-us/Content/Topics/ReleaseNotes/mobile-release-status.htm">リリース・ノート（英語版）</a>
+			<a href="../../../../../en-us/Content/Topics/ReleaseNotes/mobile-release-status.htm">リリース・ノート（英語版）</a>
 		をご参照ください。</p>
                                                 </div>
                                                 <!-- Back to Top button --><a href="#" class="sf-back-to-top"><span class="arrow"></span>Top</a>

--- a/ja-jp/Content/Topics/ReleaseNotes/okta-verify-release-notes.htm
+++ b/ja-jp/Content/Topics/ReleaseNotes/okta-verify-release-notes.htm
@@ -305,7 +305,7 @@
                                                 <div role="main" id="mc-main-content">
                                                     <h1 class="relnotes">未翻訳のドキュメント</h1>
                                                     <p>このページは、現在まだ翻訳されていません。最新のリリース・ノートについては、
-			<a href="https://help.okta.com/en-us/Content/Topics/ReleaseNotes/okta-verify-release-notes.htm">リリース・ノート（英語版）</a>
+			<a href="../../../../../en-us/Content/Topics/ReleaseNotes/okta-verify-release-notes.htm">リリース・ノート（英語版）</a>
 		をご参照ください。</p>
                                                 </div>
                                                 <!-- Back to Top button --><a href="#" class="sf-back-to-top"><span class="arrow"></span>Top</a>

--- a/ja-jp/Content/Topics/ReleaseNotes/preview.htm
+++ b/ja-jp/Content/Topics/ReleaseNotes/preview.htm
@@ -305,7 +305,7 @@
                                                 <div role="main" id="mc-main-content">
                                                     <h1 class="relnotes">未翻訳のドキュメント</h1>
                                                     <p>このページは、現在まだ翻訳されていません。最新のリリース・ノートについては、
-			<a href="https://help.okta.com/en-us/Content/Topics/ReleaseNotes/preview.htm">リリース・ノート（英語版）</a>
+			<a href="../../../../../en-us/Content/Topics/ReleaseNotes/preview.htm">リリース・ノート（英語版）</a>
 		をご参照ください。</p>
                                                 </div>
                                                 <!-- Back to Top button --><a href="#" class="sf-back-to-top"><span class="arrow"></span>Top</a>

--- a/ja-jp/Content/Topics/ReleaseNotes/production.htm
+++ b/ja-jp/Content/Topics/ReleaseNotes/production.htm
@@ -305,7 +305,7 @@
                                                 <div role="main" id="mc-main-content">
                                                     <h1 class="relnotes">未翻訳のドキュメント</h1>
                                                     <p>このページは、現在まだ翻訳されていません。最新のリリース・ノートについては、
-			<a href="https://help.okta.com/en-us/Content/Topics/ReleaseNotes/production.htm">リリース・ノート（英語版）</a>
+			<a href="../../../../../en-us/Content/Topics/ReleaseNotes/production.htm">リリース・ノート（英語版）</a>
 		をご参照ください。</p>
                                                 </div>
                                                 <!-- Back to Top button --><a href="#" class="sf-back-to-top"><span class="arrow"></span>Top</a>

--- a/ja-jp/Content/Topics/ReleaseNotes/release-faq.htm
+++ b/ja-jp/Content/Topics/ReleaseNotes/release-faq.htm
@@ -305,7 +305,7 @@
                                                 <div role="main" id="mc-main-content">
                                                     <h1 class="relnotes">未翻訳のドキュメント</h1>
                                                     <p>このページは、現在まだ翻訳されていません。最新のリリース・ノートについては、
-			<a href="https://help.okta.com/en-us/Content/Topics/ReleaseNotes/release-faq.htm">リリース・ノート（英語版）</a>
+			<a href="../../../../../en-us/Content/Topics/ReleaseNotes/release-faq.htm">リリース・ノート（英語版）</a>
 		をご参照ください。</p>
                                                 </div>
                                                 <!-- Back to Top button --><a href="#" class="sf-back-to-top"><span class="arrow"></span>Top</a>

--- a/oie/ja-jp/Content/Topics/ReleaseNotes/early-access.htm
+++ b/oie/ja-jp/Content/Topics/ReleaseNotes/early-access.htm
@@ -308,7 +308,7 @@
                                                 <div role="main" id="mc-main-content">
                                                     <h1 class="relnotes">未翻訳のドキュメント</h1>
                                                     <p>このページは、現在まだ翻訳されていません。最新のリリース・ノートについては、
-			<a href="https://help.okta.com/oie/en-us/Content/Topics/ReleaseNotes/early-access.htm">リリース・ノート（英語版）</a>
+			<a href="../../../../en-us/Content/Topics/ReleaseNotes/early-access.htm">リリース・ノート（英語版）</a>
 		をご参照ください。</p>
                                                 </div>
                                                 <!-- Back to Top button --><a href="#" class="sf-back-to-top"><span class="arrow"></span>Top</a>

--- a/oie/ja-jp/Content/Topics/ReleaseNotes/oie-ov-release-notes.htm
+++ b/oie/ja-jp/Content/Topics/ReleaseNotes/oie-ov-release-notes.htm
@@ -308,7 +308,7 @@
                                                 <div role="main" id="mc-main-content">
                                                     <h1 class="relnotes">未翻訳のドキュメント</h1>
                                                     <p>このページは、現在まだ翻訳されていません。最新のリリース・ノートについては、
-			<a href="https://help.okta.com/oie/en-us/Content/Topics/ReleaseNotes/oie-ov-release-notes.htm">リリース・ノート（英語版）</a>
+			<a href="../../../../en-us/Content/Topics/ReleaseNotes/oie-ov-release-notes.htm">リリース・ノート（英語版）</a>
 		をご参照ください。</p>
                                                 </div>
                                                 <!-- Back to Top button --><a href="#" class="sf-back-to-top"><span class="arrow"></span>Top</a>

--- a/oie/ja-jp/Content/Topics/ReleaseNotes/preview-oie.htm
+++ b/oie/ja-jp/Content/Topics/ReleaseNotes/preview-oie.htm
@@ -308,7 +308,7 @@
                                                 <div role="main" id="mc-main-content">
                                                     <h1 class="relnotes">未翻訳のドキュメント</h1>
                                                     <p>このページは、現在まだ翻訳されていません。最新のリリース・ノートについては、
-			<a href="https://help.okta.com/oie/en-us/Content/Topics/ReleaseNotes/preview-oie.htm">リリース・ノート（英語版）</a>
+			<a href="../../../../en-us/Content/Topics/ReleaseNotes/preview-oie.htm">リリース・ノート（英語版）</a>
 		をご参照ください。</p>
                                                 </div>
                                                 <!-- Back to Top button --><a href="#" class="sf-back-to-top"><span class="arrow"></span>Top</a>

--- a/oie/ja-jp/Content/Topics/ReleaseNotes/production-oie.htm
+++ b/oie/ja-jp/Content/Topics/ReleaseNotes/production-oie.htm
@@ -308,7 +308,7 @@
                                                 <div role="main" id="mc-main-content">
                                                     <h1 class="relnotes">未翻訳のドキュメント</h1>
                                                     <p>このページは、現在まだ翻訳されていません。最新のリリース・ノートについては、
-			<a href="https://help.okta.com/oie/en-us/Content/Topics/ReleaseNotes/production-oie.htm">リリース・ノート（英語版）</a>
+			<a href="../../../../en-us/Content/Topics/ReleaseNotes/production-oie.htm">リリース・ノート（英語版）</a>
 		をご参照ください。</p>
                                                 </div>
                                                 <!-- Back to Top button --><a href="#" class="sf-back-to-top"><span class="arrow"></span>Top</a>

--- a/wf/ja-jp/Content/Topics/ReleaseNotes/Workflows/preview.htm
+++ b/wf/ja-jp/Content/Topics/ReleaseNotes/Workflows/preview.htm
@@ -305,7 +305,7 @@
                                                 <div role="main" id="mc-main-content">
                                                     <h1 class="relnotes">未翻訳のドキュメント</h1>
                                                     <p>このページは、現在まだ翻訳されていません。最新のリリース・ノートについては、
-			<a href="https://help.okta.com/wf/en-us/Content/Topics/ReleaseNotes/Workflows/preview.htm">リリース・ノート（英語版）</a>
+			<a href="../../../../../en-us/Content/Topics/ReleaseNotes/Workflows/preview.htm">リリース・ノート（英語版）</a>
 		をご参照ください。</p>
                                                 </div>
                                                 <!-- Back to Top button --><a href="#" class="sf-back-to-top"><span class="arrow"></span>Top</a>

--- a/wf/ja-jp/Content/Topics/ReleaseNotes/Workflows/production.htm
+++ b/wf/ja-jp/Content/Topics/ReleaseNotes/Workflows/production.htm
@@ -305,7 +305,7 @@
                                                 <div role="main" id="mc-main-content">
                                                     <h1 class="relnotes">未翻訳のドキュメント</h1>
                                                     <p>このページは、現在まだ翻訳されていません。最新のリリース・ノートについては、
-			<a href="https://help.okta.com/wf/en-us/Content/Topics/ReleaseNotes/Workflows/production.htm">リリース・ノート（英語版）</a>
+			<a href="../../../../../en-us/Content/Topics/ReleaseNotes/Workflows/production.htm">リリース・ノート（英語版）</a>
 		をご参照ください。</p>
                                                 </div>
                                                 <!-- Back to Top button --><a href="#" class="sf-back-to-top"><span class="arrow"></span>Top</a>


### PR DESCRIPTION
The JA relnotes currently contain redirects to EN. Ensuring that these redirecting links are relative paths, not absolute.