### PR TITLE
Script for translation topic branches

### DIFF
--- a/ci-scripts/request-translation.sh
+++ b/ci-scripts/request-translation.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+cd ..
+
+export SLACK_CHANNEL='#doctools-publish'
+export targets=( "oce" "asa" "eu" "oie" "wf" "oag" )
+if [[ ! "${targets[*]}" =~ "${TARGET}" ]]; then
+    echo "No such target ${TARGET}. Exiting."
+    exit ${FAILED_SETUP}
+fi
+
+export TARGET_PATH=${TARGET}"/"
+if [ ${TARGET} == "oce" ]; then
+   TARGET_PATH=''
+fi
+
+export EN_PATH="${TARGET_PATH}en-us"
+export JA_PATH="${TARGET_PATH}ja-jp"
+
+export TOPIC_BRANCH="docs_l10n_request_${TARGET^^}_$(date +"%s")"
+
+export RESOURCE_PATHS=( "Content/Resources" "Resources" "Data" "Skins" )
+
+for RESOURCE_PATH in "${RESOURCE_PATHS[@]}"
+do
+   :
+  rsync -av --exclude "Tocs/" "${EN_PATH}/${RESOURCE_PATH}" "${JA_PATH}"
+done
+
+git checkout -b ${TOPIC_BRANCH}
+
+git add --all
+git -c user.name='CI Automation' -c user.email=${userEmail} commit -m "Copying en resources for ${TARGET^^} project"
+git push origin ${TOPIC_BRANCH}
+
+send_slack_message "${SLACK_CHANNEL}"\
+    ":white_check_mark: Requested translation for [${TARGET}]"\
+    "Commit author: ${userEmail}. Github link https://github.com/okta/okta-help/pull/new/${TOPIC_BRANCH}"\
+    "good"


### PR DESCRIPTION
## Changes:
- adds task on bacon with product name parameter (asa, oie, oce, oag, fw, eu) which will create a branch for translation
- copies resources from en-us folder to ja-jp. Resource paths:
  - Data
  - Content/Resources
  - Resources
  - Skins
  - Excludes Tocs, which has js files for translation
- when task is completed, sends notification to publish channel. (maybe will rename channel to `infodev-notifications` or something)

There are two ways of triggering task:
1. is through bacon tasks https://bacon-go.aue1e.saasure.net/tasks/CI_DOC_TOOLS_REQUEST_TRANSLATION, just run task and select corresponding target
2. is to run it via slack: `@Baconbot run task CI_DOC_TOOLS_REQUEST_TRANSLATION`

Will show both options on stand up

## Jira:
- [OKTA-549554](https://oktainc.atlassian.net/browse/OKTA-549554)

## Reviewer:
- @paulwallace-okta 