### PR TITLE
Update translation post-processing script to handle sitemaps

### DIFF
--- a/ja-jp/Content/Topics/ReleaseNotes/early-access.htm
+++ b/ja-jp/Content/Topics/ReleaseNotes/early-access.htm
@@ -305,7 +305,7 @@
                                                 <div role="main" id="mc-main-content">
                                                     <h1 class="relnotes">未翻訳のドキュメント</h1>
                                                     <p>このページは、現在まだ翻訳されていません。最新のリリース・ノートについては、
-			<a href="https://help.okta.com/en-us/Content/Topics/ReleaseNotes/early-access.htm">リリース・ノート（英語版）</a>
+			<a href="../../../../en-us/Content/Topics/ReleaseNotes/early-access.htm">リリース・ノート（英語版）</a>
 		をご参照ください。</p>
                                                 </div>
                                                 <!-- Back to Top button --><a href="#" class="sf-back-to-top"><span class="arrow"></span>Top</a>

--- a/ja-jp/Content/Topics/ReleaseNotes/mobile-release-status.htm
+++ b/ja-jp/Content/Topics/ReleaseNotes/mobile-release-status.htm
@@ -305,7 +305,7 @@
                                                 <div role="main" id="mc-main-content">
                                                     <h1 class="relnotes">未翻訳のドキュメント</h1>
                                                     <p>このページは、現在まだ翻訳されていません。最新のリリース・ノートについては、
-			<a href="https://help.okta.com/en-us/Content/Topics/ReleaseNotes/mobile-release-status.htm">リリース・ノート（英語版）</a>
+			<a href="../../../../en-us/Content/Topics/ReleaseNotes/mobile-release-status.htm">リリース・ノート（英語版）</a>
 		をご参照ください。</p>
                                                 </div>
                                                 <!-- Back to Top button --><a href="#" class="sf-back-to-top"><span class="arrow"></span>Top</a>

--- a/ja-jp/Content/Topics/ReleaseNotes/okta-verify-release-notes.htm
+++ b/ja-jp/Content/Topics/ReleaseNotes/okta-verify-release-notes.htm
@@ -305,7 +305,7 @@
                                                 <div role="main" id="mc-main-content">
                                                     <h1 class="relnotes">未翻訳のドキュメント</h1>
                                                     <p>このページは、現在まだ翻訳されていません。最新のリリース・ノートについては、
-			<a href="https://help.okta.com/en-us/Content/Topics/ReleaseNotes/okta-verify-release-notes.htm">リリース・ノート（英語版）</a>
+			<a href="../../../../en-us/Content/Topics/ReleaseNotes/okta-verify-release-notes.htm">リリース・ノート（英語版）</a>
 		をご参照ください。</p>
                                                 </div>
                                                 <!-- Back to Top button --><a href="#" class="sf-back-to-top"><span class="arrow"></span>Top</a>

--- a/ja-jp/Content/Topics/ReleaseNotes/preview.htm
+++ b/ja-jp/Content/Topics/ReleaseNotes/preview.htm
@@ -305,7 +305,7 @@
                                                 <div role="main" id="mc-main-content">
                                                     <h1 class="relnotes">未翻訳のドキュメント</h1>
                                                     <p>このページは、現在まだ翻訳されていません。最新のリリース・ノートについては、
-			<a href="https://help.okta.com/en-us/Content/Topics/ReleaseNotes/preview.htm">リリース・ノート（英語版）</a>
+			<a href="../../../../en-us/Content/Topics/ReleaseNotes/preview.htm">リリース・ノート（英語版）</a>
 		をご参照ください。</p>
                                                 </div>
                                                 <!-- Back to Top button --><a href="#" class="sf-back-to-top"><span class="arrow"></span>Top</a>

--- a/ja-jp/Content/Topics/ReleaseNotes/production.htm
+++ b/ja-jp/Content/Topics/ReleaseNotes/production.htm
@@ -305,7 +305,7 @@
                                                 <div role="main" id="mc-main-content">
                                                     <h1 class="relnotes">未翻訳のドキュメント</h1>
                                                     <p>このページは、現在まだ翻訳されていません。最新のリリース・ノートについては、
-			<a href="https://help.okta.com/en-us/Content/Topics/ReleaseNotes/production.htm">リリース・ノート（英語版）</a>
+			<a href="../../../../en-us/Content/Topics/ReleaseNotes/production.htm">リリース・ノート（英語版）</a>
 		をご参照ください。</p>
                                                 </div>
                                                 <!-- Back to Top button --><a href="#" class="sf-back-to-top"><span class="arrow"></span>Top</a>

--- a/ja-jp/Content/Topics/ReleaseNotes/release-faq.htm
+++ b/ja-jp/Content/Topics/ReleaseNotes/release-faq.htm
@@ -305,7 +305,7 @@
                                                 <div role="main" id="mc-main-content">
                                                     <h1 class="relnotes">未翻訳のドキュメント</h1>
                                                     <p>このページは、現在まだ翻訳されていません。最新のリリース・ノートについては、
-			<a href="https://help.okta.com/en-us/Content/Topics/ReleaseNotes/release-faq.htm">リリース・ノート（英語版）</a>
+			<a href="../../../../en-us/Content/Topics/ReleaseNotes/release-faq.htm">リリース・ノート（英語版）</a>
 		をご参照ください。</p>
                                                 </div>
                                                 <!-- Back to Top button --><a href="#" class="sf-back-to-top"><span class="arrow"></span>Top</a>

--- a/scripts/en2ja.json
+++ b/scripts/en2ja.json
@@ -3,33 +3,33 @@
   "description": "Replace EN string 'from' with associated JA string 'to'.",
   "pairs": [
     {
-      "from": "href=\"https://help.okta.com/asa/en-us",
-      "to": "href=\"https://help.okta.com/asa/ja-jp",
+      "from": "https://help.okta.com/asa/en-us",
+      "to": "https://help.okta.com/asa/ja-jp",
       "note": "Revise any hard-coded absolute URLs to EN topics for ASA."
     },
     {
-      "from": "href=\"https://help.okta.com/en-us",
-      "to": "href=\"https://help.okta.com/ja-jp",
+      "from": "https://help.okta.com/en-us",
+      "to": "https://help.okta.com/ja-jp",
       "note": "Revise any hard-coded absolute URLs to EN topics for Classic."
     },
     {
-      "from": "href=\"https://help.okta.com/eu/en-us",
-      "to": "href=\"https://help.okta.com/eu/ja-jp",
+      "from": "https://help.okta.com/eu/en-us",
+      "to": "https://help.okta.com/eu/ja-jp",
       "note": "Revise any hard-coded absolute URLs to EN topics for EU."
     },
     {
-      "from": "href=\"https://help.okta.com/oag/en-us",
-      "to": "href=\"https://help.okta.com/oag/ja-jp",
+      "from": "https://help.okta.com/oag/en-us",
+      "to": "https://help.okta.com/oag/ja-jp",
       "note": "Revise any hard-coded absolute URLs to EN topics for OAG."
     },
     {
-      "from": "href=\"https://help.okta.com/oie/en-us",
-      "to": "href=\"https://help.okta.com/oie/ja-jp",
+      "from": "https://help.okta.com/oie/en-us",
+      "to": "https://help.okta.com/oie/ja-jp",
       "note": "Revise any hard-coded absolute URLs to EN topics for OIE."
     },
     {
-      "from": "href=\"https://help.okta.com/wf/en-us",
-      "to": "href=\"https://help.okta.com/wf/ja-jp",
+      "from": "https://help.okta.com/wf/en-us",
+      "to": "https://help.okta.com/wf/ja-jp",
       "note": "Revise any hard-coded absolute URLs to EN topics for WF."
     },
     {

--- a/scripts/translation_postprocessing.py
+++ b/scripts/translation_postprocessing.py
@@ -105,7 +105,7 @@ def walk(lang_dir, pairs):
     """
     for root, dirs, files in os.walk(lang_dir):
         for file in files:
-            if file.endswith('.htm'):
+            if file.endswith('.htm') or file.endswith('.xml'):
                 path = os.path.join(root, file)
                 with open(path, 'r') as f:
                     text = f.read()

--- a/wf/ja-jp/Content/Topics/ReleaseNotes/Workflows/preview.htm
+++ b/wf/ja-jp/Content/Topics/ReleaseNotes/Workflows/preview.htm
@@ -305,7 +305,7 @@
                                                 <div role="main" id="mc-main-content">
                                                     <h1 class="relnotes">未翻訳のドキュメント</h1>
                                                     <p>このページは、現在まだ翻訳されていません。最新のリリース・ノートについては、
-			<a href="https://help.okta.com/wf/en-us/Content/Topics/ReleaseNotes/Workflows/preview.htm">リリース・ノート（英語版）</a>
+			<a href="../../../../../wf/en-us/Content/Topics/ReleaseNotes/Workflows/preview.htm">リリース・ノート（英語版）</a>
 		をご参照ください。</p>
                                                 </div>
                                                 <!-- Back to Top button --><a href="#" class="sf-back-to-top"><span class="arrow"></span>Top</a>

--- a/wf/ja-jp/Content/Topics/ReleaseNotes/Workflows/production.htm
+++ b/wf/ja-jp/Content/Topics/ReleaseNotes/Workflows/production.htm
@@ -305,7 +305,7 @@
                                                 <div role="main" id="mc-main-content">
                                                     <h1 class="relnotes">未翻訳のドキュメント</h1>
                                                     <p>このページは、現在まだ翻訳されていません。最新のリリース・ノートについては、
-			<a href="https://help.okta.com/wf/en-us/Content/Topics/ReleaseNotes/Workflows/production.htm">リリース・ノート（英語版）</a>
+			<a href="../../../../../wf/en-us/Content/Topics/ReleaseNotes/Workflows/production.htm">リリース・ノート（英語版）</a>
 		をご参照ください。</p>
                                                 </div>
                                                 <!-- Back to Top button --><a href="#" class="sf-back-to-top"><span class="arrow"></span>Top</a>

--- a/wf/ja-jp/Content/Topics/Workflows/build/create-table.htm
+++ b/wf/ja-jp/Content/Topics/Workflows/build/create-table.htm
@@ -342,7 +342,7 @@
                                                             <p>テーブルを複製または削除するには、そのテーブルが入っているフォルダー内でそのテーブルを確認し、テーブル名の上でカーソルを動かしたときに該当のボタンを押します。テーブルを組織内の他のユーザーと共有する場合は、そのテーブルを共有タブに入れます<MadCap:conditionalText data-mc-conditions="">。</MadCap:conditionalText></p>
                                                             <h2>フローからテーブルへのアクセス</h2>
                                                             <p>テーブルを作成した後で、そのテーブルを参照する1つ以上のフローを構築できます。</p>
-                                                            <p>フローからテーブルを使用するには、<b>［Add Functions（機能の追加）］</b>をクリックし、［Tables（テーブル）］カテゴリーから機能カードを追加します。機能カードを使用すると、レコードを作成し、読み込み、削除し、テーブルの1つからレコードを削除できます。<a href="https://help.okta.com/wf/en-us/Content/Topics/Workflows/function-reference/functions.htm#stash" target="_blank">テーブル</a>を参照してください。</p>
+                                                            <p>フローからテーブルを使用するには、<b>［Add Functions（機能の追加）］</b>をクリックし、［Tables（テーブル）］カテゴリーから機能カードを追加します。機能カードを使用すると、レコードを作成し、読み込み、削除し、テーブルの1つからレコードを削除できます。<a href="../function-reference/functions.htm#stash" target="_blank">テーブル</a>を参照してください。</p>
                                                             <h2>関連項目</h2>
                                                             <p><a href="../learn/about-tables.htm" class="MCXref xref">テーブルについて</a>
                                                             </p>


### PR DESCRIPTION
The sitemaps (EN and JA) are in XML format. Each publication has four XML files total.
We want to apply our string replacement script to the JA sitemaps (copied over from EN). This change adds a check for XML file extension, enabling parsing of these files.
Our string replacement script already includes pairs for the publication base links. We're applying that to the sitemaps.
Added bonus: The `Data/HelpSystem.xml` file includes a Support path, our string replacer adds the JA lang query string to this URL.

Additionally, changing absolute URLs to relative paths. The release notes files here are static, we don't build these in Flare.