### PR TITLE
Fixes ci permissions on files extraction

### DIFF
--- a/ci-scripts/commit-artifact.sh
+++ b/ci-scripts/commit-artifact.sh
@@ -4,10 +4,10 @@ export OUTPUT_FOLDER="../${PUBLISH_DESTINATION}"
 
 wget -O ${ARCHIVE_PATH} ${BUILT_ARTIFACT}
 
-tar -xf ${ARCHIVE_PATH} -C ${OUTPUT_FOLDER} --strip-components=1 --overwrite
+tar -xf ${ARCHIVE_PATH} -C ${OUTPUT_FOLDER} --strip-components=1 --overwrite  --no-same-permissions
 
 rm ${ARCHIVE_PATH}
-cd ..
+cd ${OKTA_HOME}/${REPO}
 
 git checkout -b ${TOPIC_BRANCH}
 


### PR DESCRIPTION
## Changes
It appears on linux job we run job with higher user privileges. That has a side effect during unpacking files from tar, files in output have more relaxed permissions (`rw-r-r` is what we usually have and `rw-rw-r` is what we get after unpacking files). As result almost every file is tracked as modified with no actual change in the content.
On unpacking tar usually applies current user mask to files, which makes result permissions to be `rw-r-r` even if file has higher permissions in archive. However for the root user it ignores `umask`, flag `--no-same-permissions` forces it to apply the mask.

After the fix, generated PR has only files with modified content:
https://github.com/okta/okta-help/pull/621/files

## Jira
- [OKTA-553185](https://oktainc.atlassian.net/browse/OKTA-553185)

## Reviewer
- @paulwallace-okta 