### PR TITLE
Fix flaky cypress test

### DIFF
--- a/tests/cypress/integration/locale_selector_spec.js
+++ b/tests/cypress/integration/locale_selector_spec.js
@@ -1,6 +1,53 @@
+let appHasStarted = false
+
+// We need to wait until change language button is initialized.
+// When on click event listener is attached to the button, it's good
+// signal to start the test.
+function spyOnAddEventListener (win) {
+  appHasStarted = false
+  // win = window object in our application
+  const addListener = win.EventTarget.prototype.addEventListener
+
+  win.EventTarget.prototype.addEventListener = function (name) {
+    if (this.className &&
+        this.className.indexOf('select-language-button') !== -1 &&
+        name === 'click') {
+      // web app added an event listener to the input box -
+      // that means the web application has started
+      appHasStarted = true
+      // restore the original event listener
+      win.EventTarget.prototype.addEventListener = addListener
+    }
+
+    /* eslint-disable-next-line prefer-rest-params */
+    return addListener.apply(this, arguments)
+  }
+}
+
+function waitForAppStart () {
+  // keeps rechecking "appHasStarted" variable
+  return new Cypress.Promise((resolve, reject) => {
+    const isReady = () => {
+      if (appHasStarted) {
+        return resolve()
+      }
+
+      setTimeout(isReady, 0)
+    }
+
+    isReady()
+  })
+}
+
+function visitAndWaitForInitialize (path) {
+  cy.visit(path, {
+    onBeforeLoad: spyOnAddEventListener,
+  }).then(waitForAppStart)
+}
+
 describe('Locale switching', () => {
   it('redirects to expected URLs for H.O.C. home', () => {
-    cy.visit('en-us/Content/index.htm')
+    visitAndWaitForInitialize('en-us/Content/index.htm')
     cy.switchLocale('Change language', '日本語 (日本)‎')
     cy.url().should('include', 'ja-jp/Content/index.htm')
     cy.switchLocale('言語の変更', 'English (United States)')
@@ -8,7 +55,7 @@ describe('Locale switching', () => {
   })
 
   it('redirects to expected URLs for ASA', () => {
-    cy.visit('asa/en-us/Content/Topics/Adv_Server_Access/docs/asa-overview.htm')
+    visitAndWaitForInitialize('asa/en-us/Content/Topics/Adv_Server_Access/docs/asa-overview.htm')
     cy.switchLocale('Change language', '日本語 (日本)‎')
     cy.url().should('include', 'asa/ja-jp/Content/Topics/Adv_Server_Access/docs/asa-overview.htm')
     cy.switchLocale('言語を変更', 'English (United States)')
@@ -16,7 +63,7 @@ describe('Locale switching', () => {
   })
 
   it('redirects to expected URLs for Classic', () => {
-    cy.visit('en-us/Content/index-admin.htm')
+    visitAndWaitForInitialize('en-us/Content/index-admin.htm')
     cy.switchLocale('Change language', '日本語 (日本)‎')
     cy.url().should('include', 'ja-jp/Content/index-admin.htm')
     cy.switchLocale('言語の変更', 'English (United States)')
@@ -24,7 +71,7 @@ describe('Locale switching', () => {
   })
 
   it('redirects to expected URLs for Classic release notes', () => {
-    cy.visit('en-us/Content/Topics/ReleaseNotes/okta-relnotes.htm')
+    visitAndWaitForInitialize('en-us/Content/Topics/ReleaseNotes/okta-relnotes.htm')
     cy.switchLocale('Change language', '日本語 (日本)‎')
     cy.url().should('include', 'ja-jp/Content/Topics/ReleaseNotes/okta-relnotes.htm')
     cy.switchLocale('言語の変更', 'English (United States)')
@@ -32,7 +79,7 @@ describe('Locale switching', () => {
   })
 
   it('redirects to expected URLs for End User', () => {
-    cy.visit('eu/en-us/Content/Topics/end-user/end-user-home.htm')
+    visitAndWaitForInitialize('eu/en-us/Content/Topics/end-user/end-user-home.htm')
     cy.switchLocale('Change language', '日本語 (日本)‎')
     cy.url().should('include', 'eu/ja-jp/Content/Topics/end-user/end-user-home.htm')
     cy.switchLocale('言語の変更', 'English (United States)')
@@ -40,7 +87,7 @@ describe('Locale switching', () => {
   })
 
   it('redirects to expected URLs for OIE', () => {
-    cy.visit('oie/en-us/Content/Topics/identity-engine/oie-index.htm')
+    visitAndWaitForInitialize('oie/en-us/Content/Topics/identity-engine/oie-index.htm')
     cy.switchLocale('Change language', '日本語 (日本)‎')
     cy.url().should('include', 'oie/ja-jp/Content/Topics/identity-engine/oie-index.htm')
     cy.switchLocale('言語を変更', 'English (United States)')
@@ -48,7 +95,7 @@ describe('Locale switching', () => {
   })
 
   it('redirects to expected URLs for OIE release notes', () => {
-    cy.visit('oie/en-us/Content/Topics/ReleaseNotes/oie-relnotes.htm')
+    visitAndWaitForInitialize('oie/en-us/Content/Topics/ReleaseNotes/oie-relnotes.htm')
     cy.switchLocale('Change language', '日本語 (日本)‎')
     cy.url().should('include', 'oie/ja-jp/Content/Topics/ReleaseNotes/oie-relnotes.htm')
     cy.switchLocale('言語を変更', 'English (United States)')
@@ -56,7 +103,7 @@ describe('Locale switching', () => {
   })
 
   it('redirects to expected URLs for Workflows', () => {
-    cy.visit('wf/en-us/Content/Topics/Workflows/workflows-main.htm')
+    visitAndWaitForInitialize('wf/en-us/Content/Topics/Workflows/workflows-main.htm')
     cy.switchLocale('Change language', '日本語 (日本)‎')
     cy.url().should('include', 'wf/ja-jp/Content/Topics/Workflows/workflows-main.htm')
     cy.switchLocale('言語の変更', 'English (United States)')


### PR DESCRIPTION
## Changes

Took main idea from here https://www.cypress.io/blog/2018/02/05/when-can-the-test-start/

We need to wait for event listener to be set for the change language button, only after that we can proceed with the test. That's required only for locale switcher tests.

## Jira
- [OKTA-551747](https://oktainc.atlassian.net/browse/OKTA-551747)

## Reviewer
- @paulwallace-okta 