### PR TITLE
Re-uses branch if it exists

### DIFF
--- a/ci-scripts/commit-artifact.sh
+++ b/ci-scripts/commit-artifact.sh
@@ -2,14 +2,26 @@
 export ARCHIVE_PATH="target.zip"
 export OUTPUT_FOLDER="../${PUBLISH_DESTINATION}"
 
-wget -O ${ARCHIVE_PATH} ${BUILT_ARTIFACT}
+cd ${OKTA_HOME}/${REPO}
+git fetch origin ${TOPIC_BRANCH}
+export RET=$?
 
+if [ "${RET}" == "0" ]
+then
+  echo "${TOPIC} exists on remote, updating"
+  git checkout ${TOPIC_BRANCH}
+else
+  echo "Creating ${TOPIC}"
+  git checkout -b ${TOPIC_BRANCH}
+fi
+
+cd ${OKTA_HOME}/${REPO}/ci-scripts
+
+wget -O ${ARCHIVE_PATH} ${BUILT_ARTIFACT}
 tar -xf ${ARCHIVE_PATH} -C ${OUTPUT_FOLDER} --strip-components=1 --overwrite  --no-same-permissions
 
 rm ${ARCHIVE_PATH}
 cd ${OKTA_HOME}/${REPO}
-
-git checkout -b ${TOPIC_BRANCH}
 
 git add --all
 git -c user.name='CI Automation' -c user.email=${userEmail} commit -m "Updates ${BUILD_NAME}"


### PR DESCRIPTION
## Changes
In addition to existing flow, we also running `git fetch origin topic_branch`:
- failure: there is no topic_branch on remote, so we create one
- success: there is a topic_branch and we fetched it to local, we can now check it out
The rest remains unchanged. For incremental changes we will have same commit message, at least for now.

## Jira
- [OKTA-555235](https://oktainc.atlassian.net/browse/OKTA-555235)

## Reviewer
- @paulwallace-okta 