### PR TITLE
Updates language attribute to ja-jp

### DIFF
--- a/scripts/en2ja.json
+++ b/scripts/en2ja.json
@@ -3,6 +3,11 @@
   "description": "Replace EN string 'from' with associated JA string 'to'.",
   "pairs": [
     {
+      "from": "lang=\"en-us\"",
+      "to": "lang=\"ja-jp\"",
+      "note": "Updates language attribute."
+    },
+    {
       "from": "https://help.okta.com/asa/en-us",
       "to": "https://help.okta.com/asa/ja-jp",
       "note": "Revise any hard-coded absolute URLs to EN topics for ASA."

--- a/scripts/test_translation_postprocessing.py
+++ b/scripts/test_translation_postprocessing.py
@@ -2,7 +2,7 @@
 
 import os.path
 import unittest
-from unittest import mock 
+from unittest import mock
 
 import translation_postprocessing as tpp
 
@@ -37,10 +37,10 @@ class TestTranslationPostProcessing(unittest.TestCase):
         # Using 'couplets' as a prop name in place of 'pairs'
         mock_load_json.return_value = dict(couplets=[{'from': 'here', 'to': 'eternity'}])
         message = "JSON data does not contain expected properties."
-        with self.assertRaises(tpp.TranslationPostProcessingException, 
+        with self.assertRaises(tpp.TranslationPostProcessingException,
                                 msg=message) as e:
             pairs = tpp.load_pairs('somefile.json')
-        assert str(e.exception) == message 
+        assert str(e.exception) == message
 
     def test_raise_for_missing_from_and_to_properties(self):
         text = "I am this close."
@@ -49,7 +49,7 @@ class TestTranslationPostProcessing(unittest.TestCase):
         pair3 = {"old": "this", "new": "that"}
         message = "JSON data does not contain expected properties."
         for pair in [pair1, pair2, pair3]:
-            with self.assertRaises(tpp.TranslationPostProcessingException, 
+            with self.assertRaises(tpp.TranslationPostProcessingException,
                                    msg=message) as e:
                 tpp.search_and_replace(text, pair)
             assert str(e.exception) == message
@@ -65,7 +65,7 @@ class TestTranslationPostProcessing(unittest.TestCase):
     def test_load_pairs_raises_for_wrong_file_type(self):
         filename = 'README.md'
         message = "'README.md' is not a valid JSON file."
-        with self.assertRaises(tpp.TranslationPostProcessingException, 
+        with self.assertRaises(tpp.TranslationPostProcessingException,
                                msg=message) as e:
             data = tpp.load_pairs(filename)
         assert str(e.exception) == message
@@ -73,7 +73,7 @@ class TestTranslationPostProcessing(unittest.TestCase):
     def test_load_pairs_raises_for_nonexistent_file(self):
         filename = 'fake.json'
         message = "'fake.json' is not a valid file path."
-        with self.assertRaises(tpp.TranslationPostProcessingException, 
+        with self.assertRaises(tpp.TranslationPostProcessingException,
                                msg=message) as e:
             data = tpp.load_pairs(filename)
         assert str(e.exception) == message

--- a/scripts/translation_postprocessing.py
+++ b/scripts/translation_postprocessing.py
@@ -7,25 +7,30 @@ Author: Paul Wallace (paul.wallace@okta.com)
 
 Returned translations of HTML content require post-processing prior to
 deployment. There are a number of string segments that are not currently
-picked up in XTM, and thus are returned untranslated. 
+picked up in XTM, and thus are returned untranslated.
 These segments include:
 
 * Attribute values (such as aria-labels)
 * URL fragements for locale-specific paths (such as `/en-us/`
-* URL query parameters for language (such as `?language=en_US`) 
+* URL query parameters for language (such as `?language=en_US`)
 
-This script can be used to execute a search-and-replace of these segments. 
+This script can be used to execute a search-and-replace of these segments.
 
 The segments that require fixing are maintained in an accompanying
-JSON file (`en2ja.json`). String replacement pairs can be revised or added 
+JSON file (`en2ja.json`). String replacement pairs can be revised or added
 therein. If in future we need to support additional languages, we can add
-JSON files for those. In that event, we will also refactor this script -- 
-possibly to pass in the `pub/lang` dir as the sole argument, 
+JSON files for those. In that event, we will also refactor this script --
+possibly to pass in the `pub/lang` dir as the sole argument,
 and handle string replacement JSON file selection in the background.
 
 This script uses modules from the Python Standard Library only. It should
-run successfully on any machine that has Python3 installed, without 
+run successfully on any machine that has Python3 installed, without
 need to fetch additional packages.
+
+To run script, get a folder path with japanese translation and pass it as first argument:
+
+        $ cd okta-help
+        $ python3 scripts/translation_postprocessing.py asa/ja-jp scripts/en2ja.json
 
 This script is accompanied by unit tests. To run the tests:
 
@@ -50,7 +55,7 @@ not_a_lang_locale_dir = "'%s' is not a valid lang-locale directory."
 # Lang-locale directory names generally follow the ISO 639-1 and ISO 3166-1
 # naming conventions for lang and locale, respectively (for example, 'ja-jp').
 # The codes will be applied in all lowercase.
-# However, for Latin America/Caribbean Spanish, the UN M49 code could be used 
+# However, for Latin America/Caribbean Spanish, the UN M49 code could be used
 # in place of ISO 3166-1 ('es-419').
 lang_locale_dir = re.compile(r'[a-z]{2}-(?:[a-z]{2}|419)')
 
@@ -63,7 +68,7 @@ def validate(lang_dir):
     if not re.match(lang_locale_dir, base_dir):
         raise TranslationPostProcessingException(not_a_lang_locale_dir % lang_dir)
     return lang_dir
-   
+
 def load_pairs(pairs_file):
     """Returns search/replace pairs from pairs_file"""
     data = _load_json(pairs_file)


### PR DESCRIPTION
## Changes
- updates both `lang="en-us"` `xml:lang="en-us"` to `ja-jp`
- removes some trailing whitespaces (VS Code does this automatically)

## Jira
- [OKTA-561129](https://oktainc.atlassian.net/browse/OKTA-561129)

## Reviewer
- @paulwallace-okta 