### PR TITLE
Create path for publishing to a new location

### DIFF
--- a/ci-scripts/commit-artifact.sh
+++ b/ci-scripts/commit-artifact.sh
@@ -17,6 +17,8 @@ fi
 
 cd ${OKTA_HOME}/${REPO}/ci-scripts
 
+mkdir -p "${OUTPUT_FOLDER}"
+
 wget -O ${ARCHIVE_PATH} ${BUILT_ARTIFACT}
 tar -xf ${ARCHIVE_PATH} -C ${OUTPUT_FOLDER} --strip-components=1 --overwrite  --no-same-permissions
 


### PR DESCRIPTION
### Changes
- creates folder for the output path, otherwise publish script fails for new location

### Jira
- [OKTA-567227](https://oktainc.atlassian.net/browse/OKTA-567227)

### Reviewer
- @paulwallace-okta 