### PR TITLE
Applies a list of built targets

### DIFF
--- a/ci-scripts/commit-artifact.sh
+++ b/ci-scripts/commit-artifact.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
-export ARCHIVE_PATH="target.zip"
-export OUTPUT_FOLDER="../${PUBLISH_DESTINATION}"
+
+export PUBLISH_TARGETS_FILE="publish_targets.txt"
+
+copy_artifact()
+{
+  OUT_FOLDER=$1
+  ARTIFACT_URL=$2
+  ARCHIVE_PATH="target.zip"
+
+  mkdir -p "${OUT_FOLDER}"
+  wget -O ${ARCHIVE_PATH} ${ARTIFACT_URL}
+  tar -xf ${ARCHIVE_PATH} -C ${OUT_FOLDER} --strip-components=1 --overwrite  --no-same-permissions
+  rm ${ARCHIVE_PATH}
+}
 
 cd ${OKTA_HOME}/${REPO}
 git fetch origin ${TOPIC_BRANCH}
@@ -17,12 +29,18 @@ fi
 
 cd ${OKTA_HOME}/${REPO}/ci-scripts
 
-mkdir -p "${OUTPUT_FOLDER}"
+if [ ${PUBLISH_TARGETS} ]
+then
+  wget -O ${PUBLISH_TARGETS_FILE} ${PUBLISH_TARGETS}
+  while IFS=$' \t\r\n' read -r artifact_link publish_to
+  do
+    copy_artifact "../${publish_to}" "${artifact_link}"
+  done < ${PUBLISH_TARGETS_FILE}
+  rm ${PUBLISH_TARGETS_FILE}
+else
+  copy_artifact "../${PUBLISH_DESTINATION}" "${BUILT_ARTIFACT}"
+fi
 
-wget -O ${ARCHIVE_PATH} ${BUILT_ARTIFACT}
-tar -xf ${ARCHIVE_PATH} -C ${OUTPUT_FOLDER} --strip-components=1 --overwrite  --no-same-permissions
-
-rm ${ARCHIVE_PATH}
 cd ${OKTA_HOME}/${REPO}
 
 git add --all


### PR DESCRIPTION
## Changes
- accepts url to file with list of built targets along with destination locations. "old" single target build still works for backward compatibility, while I'm completing changes on `info-dev` side

## Jira
- [OKTA-571529](https://oktainc.atlassian.net/browse/OKTA-571529)

## Reviewer
- @paulwallace-okta 