### PR TITLE
Wait for madcap initialization on new page

### DIFF
--- a/tests/cypress/integration/locale_selector_spec.js
+++ b/tests/cypress/integration/locale_selector_spec.js
@@ -50,6 +50,8 @@ describe('Locale switching', () => {
     visitAndWaitForInitialize('en-us/Content/index.htm')
     cy.switchLocale('Change language', '日本語 (日本)‎')
     cy.url().should('include', 'ja-jp/Content/index.htm')
+
+    visitAndWaitForInitialize('ja-jp/Content/index.htm')
     cy.switchLocale('言語を変更', 'English (United States)')
     cy.url().should('include', 'en-us/Content/index.htm')
   })
@@ -58,6 +60,8 @@ describe('Locale switching', () => {
     visitAndWaitForInitialize('asa/en-us/Content/Topics/Adv_Server_Access/docs/asa-overview.htm')
     cy.switchLocale('Change language', '日本語 (日本)‎')
     cy.url().should('include', 'asa/ja-jp/Content/Topics/Adv_Server_Access/docs/asa-overview.htm')
+
+    visitAndWaitForInitialize('asa/ja-jp/Content/Topics/Adv_Server_Access/docs/asa-overview.htm')
     cy.switchLocale('言語を変更', 'English (United States)')
     cy.url().should('include', 'asa/en-us/Content/Topics/Adv_Server_Access/docs/asa-overview.htm')
   })
@@ -66,6 +70,8 @@ describe('Locale switching', () => {
     visitAndWaitForInitialize('en-us/Content/index-admin.htm')
     cy.switchLocale('Change language', '日本語 (日本)‎')
     cy.url().should('include', 'ja-jp/Content/index-admin.htm')
+
+    visitAndWaitForInitialize('ja-jp/Content/index-admin.htm')
     cy.switchLocale('言語を変更', 'English (United States)')
     cy.url().should('include', 'en-us/Content/index-admin.htm')
   })
@@ -74,6 +80,8 @@ describe('Locale switching', () => {
     visitAndWaitForInitialize('en-us/Content/Topics/ReleaseNotes/okta-relnotes.htm')
     cy.switchLocale('Change language', '日本語 (日本)‎')
     cy.url().should('include', 'ja-jp/Content/Topics/ReleaseNotes/okta-relnotes.htm')
+
+    visitAndWaitForInitialize('ja-jp/Content/Topics/ReleaseNotes/okta-relnotes.htm')
     cy.switchLocale('言語を変更', 'English (United States)')
     cy.url().should('include', 'en-us/Content/Topics/ReleaseNotes/okta-relnotes.htm')
   })
@@ -82,6 +90,8 @@ describe('Locale switching', () => {
     visitAndWaitForInitialize('eu/en-us/Content/Topics/end-user/end-user-home.htm')
     cy.switchLocale('Change language', '日本語 (日本)‎')
     cy.url().should('include', 'eu/ja-jp/Content/Topics/end-user/end-user-home.htm')
+
+    visitAndWaitForInitialize('eu/ja-jp/Content/Topics/end-user/end-user-home.htm')
     cy.switchLocale('言語を変更', 'English (United States)')
     cy.url().should('include', 'eu/en-us/Content/Topics/end-user/end-user-home.htm')
   })
@@ -90,6 +100,8 @@ describe('Locale switching', () => {
     visitAndWaitForInitialize('oie/en-us/Content/Topics/identity-engine/oie-index.htm')
     cy.switchLocale('Change language', '日本語 (日本)‎')
     cy.url().should('include', 'oie/ja-jp/Content/Topics/identity-engine/oie-index.htm')
+
+    visitAndWaitForInitialize('oie/ja-jp/Content/Topics/identity-engine/oie-index.htm')
     cy.switchLocale('言語を変更', 'English (United States)')
     cy.url().should('include', 'oie/en-us/Content/Topics/identity-engine/oie-index.htm')
   })
@@ -98,6 +110,8 @@ describe('Locale switching', () => {
     visitAndWaitForInitialize('oie/en-us/Content/Topics/ReleaseNotes/oie-relnotes.htm')
     cy.switchLocale('Change language', '日本語 (日本)‎')
     cy.url().should('include', 'oie/ja-jp/Content/Topics/ReleaseNotes/oie-relnotes.htm')
+
+    visitAndWaitForInitialize('oie/ja-jp/Content/Topics/ReleaseNotes/oie-relnotes.htm')
     cy.switchLocale('言語を変更', 'English (United States)')
     cy.url().should('include', 'oie/en-us/Content/Topics/ReleaseNotes/oie-relnotes.htm')
   })
@@ -106,6 +120,8 @@ describe('Locale switching', () => {
     visitAndWaitForInitialize('wf/en-us/Content/Topics/Workflows/workflows-main.htm')
     cy.switchLocale('Change language', '日本語 (日本)‎')
     cy.url().should('include', 'wf/ja-jp/Content/Topics/Workflows/workflows-main.htm')
+
+    visitAndWaitForInitialize('wf/ja-jp/Content/Topics/Workflows/workflows-main.htm')
     cy.switchLocale('言語の変更', 'English (United States)')
     cy.url().should('include', 'wf/en-us/Content/Topics/Workflows/workflows-main.htm')
   })


### PR DESCRIPTION
## Changes
Heh, I've overlooked something completely.  I figured out that we have issue with madcap initialization when page loads and we start test too early. So we have `visitAndWaitForInitialize` to start test when madcap is good to go:
```
    (1) visitAndWaitForInitialize('en-us/Content/index.htm')
    (2) cy.switchLocale('Change language', '日本語 (日本)‎')
    (3) cy.url().should('include', 'ja-jp/Content/index.htm')
    (4) cy.switchLocale('言語を変更', 'English (United States)')
    (5) cy.url().should('include', 'en-us/Content/index.htm')
```
But after `cy.switchLocale('Change language', '日本語 (日本)‎')` call, browser will load another page and we don't wait for its initialization.
Before the first fix test was failing on line (2), now it's failing on line (4) since new page is loaded and we just click on the locale button immediately.

Let's hope this time I got it right

## Jira
- [OKTA-575500](https://oktainc.atlassian.net/browse/OKTA-575500)

## Reviewer
- @paulwallace-okta 