### PR TITLE
Refactoring test for EN index change

### DIFF
--- a/ja-jp/Content/index.htm
+++ b/ja-jp/Content/index.htm
@@ -152,6 +152,9 @@
                     </div>
                     <div class="main-section">
                         <div class="row outer-row sidenav-layout">
+                            <div class="sidenav-wrapper" style="display:none;">
+                                <ul class="sidenav"></ul>
+                            </div>
                             <div class="body-container">
                                 <div data-mc-content-body="True">
                                     <!-- Google Tag Manager (noscript) -->

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -41,7 +41,7 @@ function hasLeftSideNav () {
 
 function hasNoLeftSideNav () {
   cy.get('ul.sidenav')
-    .should('not.exist')
+    .should('not.be.visible')
 }
 
 function hasTOC (numOfEntries) {


### PR DESCRIPTION
In source, we removed the inline template for the top-level index file. This change affects the expected structure in acceptance tests.

* Revising the Cypress check for no left-side nav on index page
* Inserting a dummy structure in JA index (will be replaced on next translation run w/ actual EN structures)