### PR TITLE
refactors translation jobs

### DIFF
--- a/ci-scripts/receive-translation-ll.sh
+++ b/ci-scripts/receive-translation-ll.sh
@@ -3,10 +3,11 @@ export BACON_TASK_NAME="CI_DOC_TOOLS_RECEIVE_TRANSLATION_LL"
 
 source setup-translation-ll.sh
 
-export TRANSLATION_RECEIVING_BRANCH="em-translations-${TARGET}-receive-$(TZ=UTC+8 date +'%Y-%m-%d_%H-%M-%S_%s')"
+export TRANSLATION_RECEIVING_BRANCH="translations-${TARGET}-receive-$(TZ=UTC+8 date +'%Y-%m-%d_%H-%M-%S_%s')"
 
 # topic from latest main
-switch ${SHA}
+get fetch --depth=1 origin ${BASE_BRANCH}
+switch ${BASE_BRANCH}
 git checkout -b ${TRANSLATION_RECEIVING_BRANCH}
 
 # get ja files from translation branch
@@ -35,7 +36,7 @@ export HTTP_NEW_PR=$(curl \
     "title":"'"${PR_TITLE}"'",
     "body":"'"${PR_BODY}"'",
     "head":"'"${TRANSLATION_RECEIVING_BRANCH}"'",
-    "base":"'"${SHA}"'"
+    "base":"'"${BASE_BRANCH}"'"
   }')
 
 URL=$(echo ${HTTP_NEW_PR} | jq -r '.html_url')

--- a/ci-scripts/request-translation-ll.sh
+++ b/ci-scripts/request-translation-ll.sh
@@ -3,6 +3,9 @@ export BACON_TASK_NAME="CI_DOC_TOOLS_REQUEST_TRANSLATION_LL"
 
 source setup-translation-ll.sh
 
+git fetch --depth=1 origin ${BASE_BRANCH}
+export BASE_BRANCH_SHA=$(git rev-parse origin/${BASE_BRANCH})
+
 git fetch --depth=1 origin ${TRANSLATION_BRANCH}
 git reset --hard FETCH_HEAD
 
@@ -10,7 +13,7 @@ git switch ${TRANSLATION_BRANCH}
 
 # checkout latest en-us sources
 pushd ${EN_PATH}
-git restore --source origin/${SHA} -- . ':!*/Topics/ReleaseNotes/*'
+git restore --source origin/${BASE_BRANCH} -- . ':!*/Topics/ReleaseNotes/*'
 popd
 
 # copy en-us resources to en-ja
@@ -23,11 +26,10 @@ done
 cp -f "${EN_PATH}/Sitemap.xml" "${JA_PATH}/Sitemap.xml"
 
 pushd ${JA_PATH}
-git restore --source origin/${SHA} -- 'Data/Tocs/*'
+git restore --source origin/${BASE_BRANCH} -- 'Data/Tocs/*'
 popd
 
-# somehow this call makes git diff-index work properly all the time
-git status -s
+git add --all
 
 if git diff-index --quiet HEAD --; then
   echo 'No changes detected in [${EN_PATH}]'
@@ -39,9 +41,10 @@ if git diff-index --quiet HEAD --; then
   exit
 fi
 
-git add --all
 git -c user.name='CI Automation' -c user.email=${userEmail} \
-  commit -m "$(TZ=UTC+8 date +'%Y-%m-%d %H:%M:%S') Copying en resources and files for ${TARGET^^} project"
+  commit -m "$(TZ=UTC+8 date +'%Y-%m-%d %H:%M:%S') Copying en resources and files for ${TARGET^^} project." \
+  -m "Branch: ${BASE_BRANCH}" \
+  -m "SHA: ${BASE_BRANCH_SHA}"
 git push origin ${TRANSLATION_BRANCH}
 
 send_slack_message "${SLACK_CHANNEL}" \

--- a/ci-scripts/setup-translation-ll.sh
+++ b/ci-scripts/setup-translation-ll.sh
@@ -13,7 +13,16 @@ if [ ${TARGET} == "oce" ]; then
   TARGET_PATH=''
 fi
 
-export TRANSLATION_BRANCH=docs_translations_gh_${TARGET^^}
+export GH_PREFIX=
+export BASE_BRANCH=master
+if [ ${IS_GH} == "true" ]; then
+  GH_PREFIX=gh_
+  BASE_BRANCH=gh-pages
+fi
+
+export TRANSLATION_BRANCH=docs_translations_${GH_PREFIX}${TARGET^^}
+echo ${TRANSLATION_BRANCH}
+export TRANSLATION_BRANCH=em-translations-asa
 export EN_PATH="${TARGET_PATH}en-us"
 export JA_PATH="${TARGET_PATH}ja-jp"
 


### PR DESCRIPTION
### Changes
- removes `em-` from receiving branch name 😄
- instead of using `SHA` to copy to or from it's now fixed `gh-pages` or `master`
- adds base branch SHA and name so it's easy to find source for current translation request
- adds `IS_GH` parameter, which configures long lived translation branch name and source branch. By default it is true, will use `_gh_{target}` and `gh-pages`.

### Jira
[OKTA-597088](https://oktainc.atlassian.net/browse/OKTA-597088)

### Reviewer
- @paulwallace-okta 