### PR TITLE
Excludes release notes for lowercase path

### DIFF
--- a/ci-scripts/request-translation-ll.sh
+++ b/ci-scripts/request-translation-ll.sh
@@ -13,7 +13,7 @@ git switch ${TRANSLATION_BRANCH}
 
 # checkout latest en-us sources
 pushd ${EN_PATH}
-git restore --source origin/${BASE_BRANCH} -- . ':!*/Topics/ReleaseNotes/*'
+git restore --source origin/${BASE_BRANCH} -- . ':!*/Topics/ReleaseNotes/*' ':!*/topics/releasenotes/*'
 popd
 
 # copy en-us resources to en-ja


### PR DESCRIPTION
## Changes
- When syncing en-us contents from gh-pages to the translation branch, we skip ReleaseNotes. For the Netlify project, we need to skip relesenotes (all lowercase)

## Jira
[OKTA-611207](https://oktainc.atlassian.net/browse/OKTA-611207)

## Reviewer
- @paulwallace-okta 