### PR TITLE
Em okta 627781 add tests suite

### DIFF
--- a/.bacon.yml
+++ b/.bacon.yml
@@ -1,0 +1,11 @@
+test_suites:
+- name: cypress
+  script_path: /root/okta/okta-help/ci-scripts
+  script_name: cypress
+  sort_order: '1'
+  timeout: '15'
+  criteria: MERGE
+  queue_name: small
+  script_env:
+    SHALLOW_CLONE: true
+    SKIP_CACHE_SETUP: true

--- a/ci-scripts/cypress.sh
+++ b/ci-scripts/cypress.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# waiting for 10 minutes at most
+export MAX_ATTEMPTS=30
+export SLEEP_TIME=20
+export GITHUB_TOKEN
+if [ "${GITHUB_ORG}" == "atko-eng" ]; then
+  get_vault_secret_key eng-services/github-uplift/eng-productivity-ci-bot-okta atko GITHUB_TOKEN
+else
+  get_vault_secret_key eng-services/github-uplift/eng-productivity-ci-bot-okta okta GITHUB_TOKEN
+fi
+
+# In case if Github has not started tests yet
+sleep ${SLEEP_TIME}
+
+until [ ${MAX_ATTEMPTS} -eq 0 ]; do
+  export HTTP_WF_RUNS=$(curl -L \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    https://api.github.com/repos/${GITHUB_ORG}/${REPO}/actions/runs?head_sha=${SHA} )
+
+  export TOTAL_COUNT=$(echo ${HTTP_WF_RUNS} | jq -r '.total_count')
+  export CONCLUSION=$(echo ${HTTP_WF_RUNS} | jq -r '.workflow_runs[0].conclusion')
+  export STATUS=$(echo ${HTTP_WF_RUNS} | jq -r '.workflow_runs[0].status')
+
+  if [ "${TOTAL_COUNT}" = "0" ]; then
+    echo "No workflows found. Did you create a PR?"
+    exit ${TEST_FAILURE}
+  fi
+
+  echo "status: ${STATUS} conclusion: ${CONCLUSION}"
+
+  if [ "${STATUS}" = "completed" ]; then
+    if [ "${CONCLUSION}" = "success" ]; then
+      echo "succeeded"
+      exit
+    fi
+    echo "failed"
+    exit ${TEST_FAILURE}
+  fi
+
+  MAX_ATTEMPTS=$(($MAX_ATTEMPTS - 1))
+  sleep ${TEST_FAILURE}
+done
+
+exit ${TEST_FAILURE}


### PR DESCRIPTION
## Change
It was a surprisingly challenging task. There are two approaches for it:
- Duplicate cypress test in bacon task. Run `yarn install` and `yarn cy:run`.
- Wait for GitHub workflow action from the bacon task.

For 1) I could not get cypress installed correctly on bacon, we also needed a different `node` version, because the default is incompatible with our setup. And we would also run tests two times, the first one from github and the second one from bacon.
2) is a bit exotic 😄 We're querying status from GH, depending on when we start the bacon task, we may already have test results in GH. Also, our GH action is configured for PRs only and bacon shows test for every commit even if there is no PR (for this case test should fail)

Api can be found here https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository . Let's try an approach with polling GH

## Ticket
- [OKTA-627781](https://oktainc.atlassian.net/browse/OKTA-627781)

## Reviewer
- @paulwallace-okta 