### PR TITLE
Adding l10n string replacement pair

### DIFF
--- a/scripts/en2ja.json
+++ b/scripts/en2ja.json
@@ -119,6 +119,11 @@
       "from": "href=\"../../wf/en-us/Content/",
       "to": "href=\"../../wf/ja-jp/Content/",
       "note": "This pattern appears only in the OCE top-level index page, relative path links to other pubs"
+    },
+    {
+      "from": "microsoft.com/en-us/",
+      "to": "microsoft.com/ja-jp/",
+      "note": "In our docs, we have many links to Microsoft, and there are several subdomains. Microsoft has i18nized these links."
     }
   ]
 }


### PR DESCRIPTION
We have several tickets generated from LQA feedback, recommending we update our Microsoft links for JA.
Helpfully, Microsoft has i18nized their content, and publishes in many languages.
They also maintain several subdomains, to which we link.
Adding a string replacement pair to update the links to Microsoft resources for JA.