### PR TITLE
clears en-us folder for prod builds

### DIFF
--- a/ci-scripts/commit-artifact.sh
+++ b/ci-scripts/commit-artifact.sh
@@ -8,6 +8,10 @@ copy_artifact()
   ARTIFACT_URL=$2
   ARCHIVE_PATH="target.zip"
 
+  if [ "${IS_PROD}" == "true" ]
+  then
+    rm -rf "${OUT_FOLDER}/en-us"
+  fi
   mkdir -p "${OUT_FOLDER}"
   wget -O ${ARCHIVE_PATH} ${ARTIFACT_URL}
   unzip -o ${ARCHIVE_PATH} -d ${OUT_FOLDER}


### PR DESCRIPTION
## change
- clears `en-us` folder for prod builds before copying built artifact to it.
- betas targets don't have `en-us` path, the script won't do anything in that case

## ticket
[OKTA-649406](https://oktainc.atlassian.net/browse/OKTA-649406)

## reviewer
- @paulwallace-okta 