### PR TITLE
fixes cypress tests

### DIFF
--- a/ci-scripts/cypress.sh
+++ b/ci-scripts/cypress.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 pushd ${OKTA_HOME}/${REPO}
 
+export UPLOAD_ARTIFACT_URL=${ARTIFACTORY_URL}/topic/com/okta/flare/cypress_${BRANCH}_${SHA:0:10}.zip
+export CURL="curl -Lk -u ${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD} -m 30 --connect-timeout 30 -f "
+export CYPRESS_ZIP="cypress.zip"
+export CYPRESS_SCREENS="tests/cypress/screenshots/*"
+
 # Start xvfb
 Xvfb :99 -screen 0 1366x768x16 &
 
@@ -25,6 +30,9 @@ fi
 
 if ! npx cypress run --headless; then
     echo "failed cypress tests"
+
+    zip -r ${CYPRESS_ZIP} ${CYPRESS_SCREENS}
+    ${CURL} --upload-file ${CYPRESS_ZIP} ${UPLOAD_ARTIFACT_URL}
+
     exit ${BUILD_FAILURE}
 fi
-

--- a/cypress.json
+++ b/cypress.json
@@ -12,6 +12,6 @@
     "runMode": 2,
     "openMode": 2
   },
-  "viewportWidth": 1200,
-  "viewportHeight": 800
+  "viewportWidth": 1600,
+  "viewportHeight": 1000
 }

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -103,6 +103,11 @@ function hasTopMenuBar (numTopLinks, numChildLinks) {
       cy.wrap($el)
         .should('have.attr', 'href')
     })
+
+  cy.get('div.dropdown-content')
+    .eq(0)
+    .should('be.visible')
+    .invoke('hide')
 }
 
 function hasBodyContent () {


### PR DESCRIPTION
## Changes
- Hides a drop-down menu, when it's no longer needed. Just noticed on the local run that drop down is not automatically closed when test continues to the next steps <img width="758" alt="image" src="https://github.com/okta/okta-help/assets/4158731/10a53a79-879b-4e88-9dcb-7e671e78753b">
- Changes viewport configuration so the test will pass, but we have a bug in UI when Coveo search bar is not visible: https://oktainc.atlassian.net/browse/OKTA-667840
- Uploads screenshots from failed tests, so it will be easier to investigate issues in the future.

## Ticket
[OKTA-664039](https://oktainc.atlassian.net/browse/OKTA-664039)

## Reviewer
- @paulwallace-okta 