### PR TITLE
Syncs translated folder with en-us

### DIFF
--- a/ci-scripts/receive-translation-ll.sh
+++ b/ci-scripts/receive-translation-ll.sh
@@ -10,8 +10,12 @@ git fetch --depth=1 origin ${BASE_BRANCH}
 git switch ${BASE_BRANCH}
 git checkout -b ${TRANSLATION_RECEIVING_BRANCH}
 
-# get ja files from translation branch
 git fetch --depth=1 origin ${TRANSLATION_BRANCH}
+
+# get en-us sitemap for syncing ja-jp content
+git restore --source origin/${TRANSLATION_BRANCH} -- ${EN_PATH}/Sitemap.xml
+
+# get ja-jp files from translation branch
 pushd ${JA_PATH}
 git restore --source origin/${TRANSLATION_BRANCH} -- .
 popd
@@ -19,6 +23,9 @@ popd
 # run post processing
 yum -y install python3-devel
 python3 scripts/translation_postprocessing.py ${TARGET}
+
+# revert en-us sitemap
+git checkout -- ${EN_PATH}/Sitemap.xml
 
 git add --all
 git -c user.name='CI Automation' -c user.email=${userEmail} commit -m "$(TZ=UTC+8 date +'%Y-%m-%d %H:%M:%S') Receiving translation for ${TARGET^^} project"

--- a/scripts/translation_postprocessing.py
+++ b/scripts/translation_postprocessing.py
@@ -139,12 +139,65 @@ def restore_release_notes(target):
     if os.path.isdir(release_notes_backup):
         shutil.move(release_notes_backup, release_notes)
 
+def remove_stale_files(lang_dir, sitemap_files):
+    """Walk the dir tree from `lang_dir`, applying string replacements
+       for each pair in `pairs`.
+    """
+    files_for_deletion = []
+    base_to_remove = lang_dir + '/content/topics/'
+    release_notes_path = base_to_remove + 'releasenotes/'
+
+    for root, dirs, files in os.walk(lang_dir):
+        for file in files:
+            if not file.endswith('.htm'):
+                continue
+
+            path = os.path.join(root, file)
+
+            if not path.startswith(base_to_remove):
+                continue
+
+            sitemap_file = path.replace(base_to_remove, '')
+            if not sitemap_file in sitemap_files:
+                if path.startswith(release_notes_path):
+                    print("skip rel notes:", sitemap_file)
+                    continue
+                print("delete stale:", sitemap_file)
+                files_for_deletion.append(path)
+
+    for file in files_for_deletion:
+        os.remove(file)
+
+def get_sitemap_files(sitemap_path):
+    matches = []
+
+    file_path_regex = "/en-us/content/topics/(.*htm)</loc>"
+    regexp = re.compile(file_path_regex)
+    with open (sitemap_path, 'r') as sitemap:
+        for line in sitemap:
+            matches += regexp.findall(line)
+
+    return matches
+
+def sync_files_with_en_folder(target):
+    """ Synchronizes file structure in translated folder with english folder.
+        Is required for removing stale files in ja-jp folder.
+    """
+    sitemap_path = en_us if target == 'oce' else target + '/' + en_us
+    sitemap_path += '/Sitemap.xml'
+    sitemap_files = get_sitemap_files(sitemap_path)
+
+    lang_dir = get_lang_dir(target)
+
+    remove_stale_files(lang_dir, sitemap_files)
+
 def main(target, pairs_file):
     if target not in targets:
         raise TranslationPostProcessingException(invalid_target % target)
 
     replace_strings(target, pairs_file)
     restore_release_notes(target)
+    sync_files_with_en_folder(target)
 
 class TranslationPostProcessingException(Exception):
     def __init__(self, msg):

--- a/scripts/translation_postprocessing.py
+++ b/scripts/translation_postprocessing.py
@@ -140,8 +140,8 @@ def restore_release_notes(target):
         shutil.move(release_notes_backup, release_notes)
 
 def remove_stale_files(lang_dir, sitemap_files):
-    """Walk the dir tree from `lang_dir`, applying string replacements
-       for each pair in `pairs`.
+    """Walk the dir tree from `lang_dir`, deletes files which are not included
+       into sitemap.
     """
     files_for_deletion = []
     base_to_remove = lang_dir + '/content/topics/'


### PR DESCRIPTION
## Changes
- checks out en-us sitemap from long-lived translation branch
- reads all file names from sitemap
- iterates through ja-jp topics and deletes those that are not in a sitemap. Exceptions are release notes and files not in the topics folder.

Here is the PR from the receiving job https://github.com/okta/okta-help/pull/1733 - look at ja-jp topics folder.

## Ticket
- [OKTA-671306](https://oktainc.atlassian.net/browse/OKTA-671306)

## Reviewer
- @paulwallace-okta 