### PR TITLE
OKTA-696583: H.O.C. index page titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta http-equiv="Refresh" content="0.000,url=./okta_help.htm?id=csh-index">
+    <title>Okta Docs</title>
+    <meta http-equiv="refresh" content="0; url=./okta_help.htm?id=csh-index" />
 </head>
 <body>
 </body>

--- a/okta_help.htm
+++ b/okta_help.htm
@@ -1,1 +1,1 @@
-<!doctype html><html><head><meta charset="utf-8"><title>Okta help</title><meta name="viewport" content="width=device-width,initial-scale=1"><script defer="defer" src="i18n-util.bundle.4112cdf601ba713c685c.js"></script></head><body></body></html>
+<!doctype html><html><head><meta charset="utf-8"><title>Okta Docs</title><meta name="viewport" content="width=device-width,initial-scale=1"><script defer="defer" src="i18n-util.bundle.4112cdf601ba713c685c.js"></script></head><body></body></html>


### PR DESCRIPTION
Titles should render "Okta Docs" in apps that render titles from embedded links, such as Jira and Confluence.

Also, revising the meta http-equiv syntax, the content attr was non-standard format, now formatted correctly.