### PR TITLE
chore(ci): Improve checkout speed by shallow cloning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ aliases:
     run:
       name: Fast checkout with shallow clone
       command: |
+        mkdir /home/circleci/.ssh
         ssh-keyscan -p 443 ssh.github.com >> /home/circleci/.ssh/known_hosts
         git clone --depth 1 "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,15 @@ executors:
       - image: cimg/node:16.14.0
 
 aliases:
+
+  # https://support.circleci.com/hc/en-us/articles/360045096514-Shallow-Repository-Cloning
+  fast_checkout: &fast_checkout
+    checkout:
+      name: Fast checkout
+      command: |
+        ssh-keyscan -p 443 ssh.github.com >> ~/.ssh/known_hosts
+        git clone --depth 1 "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
+
   restore_cache: &restore_cache
     restore_cache:
       name: Restore Npm Package Cache
@@ -36,9 +45,7 @@ jobs:
         default: false
     executor: node
     steps:
-      # https://support.circleci.com/hc/en-us/articles/360045096514-Shallow-Repository-Cloning
-      # - checkout
-      - run: git clone --depth 1 "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
+      - <<: *fast_checkout
       - <<: *restore_cache
       - <<: *install_node_modules
       - <<: *save_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   cypress: cypress-io/cypress@3
+  advanced-checkout: vsco/advanced-checkout@1.1.0
 
 executors:
   node:
@@ -9,15 +10,6 @@ executors:
       - image: cimg/node:16.14.0
 
 aliases:
-
-  # https://support.circleci.com/hc/en-us/articles/360045096514-Shallow-Repository-Cloning
-  fast_checkout: &fast_checkout
-    run:
-      name: Fast checkout with shallow clone
-      command: |
-        mkdir /home/circleci/.ssh
-        ssh-keyscan -p 443 ssh.github.com >> /home/circleci/.ssh/known_hosts
-        git clone --depth 1 "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
 
   restore_cache: &restore_cache
     restore_cache:
@@ -46,7 +38,7 @@ jobs:
         default: false
     executor: node
     steps:
-      - <<: *fast_checkout
+      - advanced-checkout/shallow-checkout
       - <<: *restore_cache
       - <<: *install_node_modules
       - <<: *save_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ jobs:
       name: cypress/default
       node-version: "16.14.0"
     steps:
+      - advanced-checkout/shallow-checkout
       - cypress/install:
           package-manager: "yarn"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,9 @@ jobs:
         default: false
     executor: node
     steps:
-      - checkout
+      # https://support.circleci.com/hc/en-us/articles/360045096514-Shallow-Repository-Cloning
+      # - checkout
+      - run: git clone --depth 1 "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
       - <<: *restore_cache
       - <<: *install_node_modules
       - <<: *save_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ aliases:
     run:
       name: Fast checkout with shallow clone
       command: |
-        ssh-keyscan -p 443 ssh.github.com >> ~/.ssh/known_hosts
+        ssh-keyscan -p 443 ssh.github.com >> /home/circleci/.ssh/known_hosts
         git clone --depth 1 "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
 
   restore_cache: &restore_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ aliases:
 
   # https://support.circleci.com/hc/en-us/articles/360045096514-Shallow-Repository-Cloning
   fast_checkout: &fast_checkout
-    checkout:
-      name: Fast checkout
+    run:
+      name: Fast checkout with shallow clone
       command: |
         ssh-keyscan -p 443 ssh.github.com >> ~/.ssh/known_hosts
         git clone --depth 1 "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"


### PR DESCRIPTION
I noticed that the checkout steps for the project were taking almost 3 minutes.

This attempts to change the step to use a shallow clone:
https://support.circleci.com/hc/en-us/articles/360045096514-Shallow-Repository-Cloning

There's another good article on the subject from GitHub here:
https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/

Locally for me this is greatly improved, and the time spend checking out is time the resource class compute time is computed, so this may both improve pipeline performance as well as reduce credit spend.

So long as the Cypress testing and deployment need only the `HEAD` of the given branch or pipeline, this may be sufficient?