### PR TITLE
chore(ci): Speed up deploy step with shallow checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   cypress: cypress-io/cypress@3
+  advanced-checkout: vsco/advanced-checkout@1.1
 
 executors:
   node:
@@ -36,7 +37,7 @@ jobs:
         default: false
     executor: node
     steps:
-      - checkout
+      - advanced-checkout/shallow-checkout
       - <<: *restore_cache
       - <<: *install_node_modules
       - <<: *save_cache


### PR DESCRIPTION
This PR speeds up the deploy step in CI by performing a shallow checkout. I noticed it was taking ~3 minutes for every PR and production deploys off mainline. This should help both improve performance of the pipeline, as well as (slightly) reduce compute credit consumption in CircleCI.  Supports OKTA-728901.

For the Cypress jobs, the `checkout` is built in and that'll need a different workaround.

| Before | After |
| - | - |
|  <img width="1241" alt="image" src="https://github.com/okta/okta-help/assets/167119170/84f8894e-46aa-4c1b-a72d-fe9c5bd3cab4">  | |
