### PR TITLE
Em okta 755603

### DIFF
--- a/ci-scripts/request-translation-ll.sh
+++ b/ci-scripts/request-translation-ll.sh
@@ -27,6 +27,9 @@ cp -f "${EN_PATH}/Sitemap.xml" "${JA_PATH}/Sitemap.xml"
 
 pushd ${JA_PATH}
 git restore --source origin/${BASE_BRANCH} -- 'Data/Tocs/*'
+    pushd Data
+    git restore --source origin/${TRANSLATION_BRANCH} -- 'Search*.js'
+    popd
 popd
 
 git add --all


### PR DESCRIPTION
## Changes
- Restores `Search*.js` files from LL translation branch, so that when resources from en-us are copied to ja-jp folder files required for ja-jp search remain untouched.

## Ticket
- [OKTA-755603](https://oktainc.atlassian.net/browse/OKTA-755603)

## Reviewer
- @paulwallace-okta 