### PR TITLE
Starts i18n sync task

### DIFF
--- a/ci-scripts/receive-translation-ll.sh
+++ b/ci-scripts/receive-translation-ll.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-export BACON_TASK_NAME="CI_DOC_TOOLS_RECEIVE_TRANSLATION_LL"
-
 source setup-translation-ll.sh
 
 export TRANSLATION_RECEIVING_BRANCH="translations-${TARGET}-receive-$(TZ=UTC+8 date +'%Y-%m-%d_%H-%M-%S_%s')"

--- a/ci-scripts/request-translation-ll.sh
+++ b/ci-scripts/request-translation-ll.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export BACON_TASK_NAME="CI_DOC_TOOLS_REQUEST_TRANSLATION_LL"
+export BACON_TASK_NAME="I18N_SYNC_TRANSLATIONS"
 
 source setup-translation-ll.sh
 
@@ -49,6 +49,17 @@ git -c user.name='CI Automation' -c user.email=${userEmail} \
   -m "Branch: ${BASE_BRANCH}" \
   -m "SHA: ${BASE_BRANCH_SHA}"
 git push origin ${TRANSLATION_BRANCH}
+
+export JSON_DATA='{
+  "xtmBranchRegex":"origin/'${TRANSLATION_BRANCH}'",
+  "i18nRepo":"okta-help"
+}'
+export BACON_TASK_RUN_ID=$(run_bacon_task_by_name "${BACON_TASK_NAME}" "${JSON_DATA}")
+
+if ! wait_for_bacon_task_to_complete "${BACON_TASK_RUN_ID}" $((TIMEOUT * 60));
+then
+  exit ${FAILED_SETUP}
+fi
 
 send_slack_message "${SLACK_CHANNEL}" \
   ":white_check_mark: Requested translation for [${TARGET^^}]" \


### PR DESCRIPTION
### Changes
- Starts i18n sync after the request translation script is done.

[Dry run](https://bacon-go.aue1e.saasure.net/tasks/I18N_SYNC_TRANSLATIONS?taskId=d77628757ecf445d919898bb414d6aa7) on i18n sync triggered from [test bacon task](https://bacon-go.aue1e.saasure.net/tasks/CI_DOC_TOOLS_TEST?taskId=a140584853b64895b6044515f3f59b9a)

### Ticket
- [OKTA-821634](https://oktainc.atlassian.net/browse/OKTA-821634)

### Reviewer
- @paulwallace-okta 